### PR TITLE
Add Storage Support for Amazon DynamoDB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ packages/electron/app
 packages/electron/dist
 *.env
 packages/pwa/dist
+pwa

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -17,6 +17,7 @@
     "@padloc/core": "^3.0.9",
     "@padloc/locale": "^3.0.6",
     "@types/stripe": "^6.26.5",
+    "aws-sdk": "^2.565.0",
     "fs-extra": "^7.0.1",
     "level": "^5.0.1",
     "nodemailer": "^4.6.7",

--- a/packages/server/src/storage.ts
+++ b/packages/server/src/storage.ts
@@ -2,6 +2,9 @@
 import level from "level";
 import { Storage, Storable, StorableConstructor } from "@padloc/core/src/storage";
 import { Err, ErrorCode } from "@padloc/core/src/error";
+import { AwsRegion } from "aws-sdk/clients/servicequotas";
+import DynamoDB from "aws-sdk/clients/dynamodb";
+import { CredentialProviderChain } from "aws-sdk";
 
 export class LevelDBStorage implements Storage {
     private _db: any;
@@ -30,6 +33,81 @@ export class LevelDBStorage implements Storage {
 
     async delete<T extends Storable>(obj: T) {
         await this._db.del(`${obj.kind}_${obj.id}`);
+    }
+
+    async clear() {
+        throw "not implemented";
+    }
+}
+
+// Add support for AWS DynamoDB
+// Limitations with DynamoDB is that Total Item Size is only 400KB
+// This means that a Vault can not exceed 400KB In size with the current
+// Storage Implimentation as is. That's about 500 Standard Items
+export class DynamoDBStorage implements Storage {
+    private _db: any;
+    private table: string;
+
+    constructor(public credentials: CredentialProviderChain, region: AwsRegion, table: string) {
+        this._db = new DynamoDB({ credentialProvider: credentials, region: region });
+        this.table = table;
+    }
+
+    async get<T extends Storable>(cls: StorableConstructor<T> | T, id: string) {
+        try {
+            const res = cls instanceof Storable ? cls : new cls();
+            const raw = await this._db
+                .getItem({
+                    Key: {
+                        storeable: {
+                            S: `${res.kind}_${id}`
+                        }
+                    },
+                    TableName: this.table
+                })
+                .promise();
+
+            // DynamoDB does not return an error on empty result.
+            // Checking whether the _item_ property is defined to
+            // determine whether the Item is not found.
+
+            if (typeof raw.Item === "undefined") {
+                throw new Err(ErrorCode.NOT_FOUND);
+            } else {
+                return res.fromJSON(raw.Item.secret.S);
+            }
+        } catch (e) {
+            throw e;
+        }
+    }
+
+    async save<T extends Storable>(obj: T) {
+        await this._db
+            .putItem({
+                Item: {
+                    storeable: {
+                        S: `${obj.kind}_${obj.id}`
+                    },
+                    secret: {
+                        S: obj.toJSON()
+                    }
+                },
+                TableName: this.table
+            })
+            .promise();
+    }
+
+    async delete<T extends Storable>(obj: T) {
+        await this._db
+            .deleteItem({
+                Key: {
+                    storeable: {
+                        S: `${obj.kind}_${obj.id}`
+                    }
+                },
+                TableName: this.table
+            })
+            .promise();
     }
 
     async clear() {


### PR DESCRIPTION
Adding support for using Amazon DynamoDB as a storage provider to provide persistence across multiple instances of `padloc-server` for Elasticity and Availability. 

### New Configuration Options Implemented
#### Environment Variables
| VARIABLE NAME  | TYPE |  ACCEPTED VALUES |DEFAULT|
| ----------- | ----------- |----------- |----------- |
| STORAGE_PROVIDER      |  Storage Provider       | LevelDB, DynamoDB  |LevelDB |
| AWS_REGION   | String        | aws region name|us-west-2 |
| AWS_DDB_TABLE   | String        | pre-created DynamoDB table name |padloc |

#### Requirements. 
A pre-created DynamoDB table with `Primary partition key` named `storeable` of type `String`


