### PR TITLE
Add CI - Run Test

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,17 @@
+name: Run Tests
+
+on: [push]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+      - run: |
+          npm ci
+          npm test
+        env:
+          CI: true

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Padloc
 
+[![](https://github.com/padloc/padloc/workflows/Run%20Tests/badge.svg)](https://github.com/padloc/padloc/actions?workflow=Run+Tests)
+
 Simple, secure password and data management for individuals and teams (formerly known as Padlock).
 
 This repo is split into multiple packages:


### PR DESCRIPTION
This makes it so that on every push (includes PRs), dependencies and tests run on GitHub Actions.

It also adds a small badge reporting the latest push/run on the `master` branch.

Fixes #321