### PR TITLE
CI: Build Web Extension

### DIFF
--- a/.github/workflows/build-web-extension.yml
+++ b/.github/workflows/build-web-extension.yml
@@ -45,5 +45,5 @@ jobs:
               uses: actions/upload-artifact@v2
               with:
                   name: unsigned-extension-chrome-${{ github.sha }}.zip
-                  path: chrome.zip
+                  path: packages/extension/chrome.zip
                   if-no-files-found: error

--- a/.github/workflows/build-web-extension.yml
+++ b/.github/workflows/build-web-extension.yml
@@ -47,7 +47,7 @@ jobs:
               uses: actions/upload-artifact@v2
               with:
                   name: signed-web-extension-firefox-${{ github.sha }}
-                  path: packages/extension/dist/*.xpi
+                  path: packages/extension/dist/web-ext-artifacts/*.xpi
                   if-no-files-found: error
             - name: Archive Unsigned Web Extension (Chrome)
               uses: actions/upload-artifact@v2
@@ -55,5 +55,7 @@ jobs:
                   name: unsigned-web-extension-chrome-${{ github.sha }}
                   path: |
                       packages/extension/dist
+                      !web-ext-artifacts
                       !*.xpi
+                      !*.zip
                   if-no-files-found: error

--- a/.github/workflows/build-web-extension.yml
+++ b/.github/workflows/build-web-extension.yml
@@ -38,13 +38,13 @@ jobs:
             - name: Archive Signed Web Extension (Firefox)
               uses: actions/upload-artifact@v2
               with:
-                  name: signed-web-extension-firefox-${{ github.sha }}
+                  name: padloc-web-extension-${{ github.sha }}-signed.xpi
                   path: packages/extension/dist/web-ext-artifacts/*.xpi
                   if-no-files-found: error
             - name: Archive Unsigned Web Extension (Chrome)
               uses: actions/upload-artifact@v2
               with:
-                  name: unsigned-web-extension-chrome-${{ github.sha }}
+                  name: padloc-web-extension-${{ github.sha }}-unsigned
                   path: |
                       packages/extension/dist
                       !packages/extension/dist/web-ext-artifacts

--- a/.github/workflows/build-web-extension.yml
+++ b/.github/workflows/build-web-extension.yml
@@ -21,7 +21,7 @@ on:
 jobs:
     archive:
         runs-on: ubuntu-latest
-        environment: ${{ github.event.inputs.environment || "Local" }}
+        environment: ${{ github.event.inputs.environment || "Local' }}
         steps:
             - uses: actions/checkout@v2
             - uses: actions/setup-node@v1

--- a/.github/workflows/build-web-extension.yml
+++ b/.github/workflows/build-web-extension.yml
@@ -55,7 +55,6 @@ jobs:
                   name: unsigned-web-extension-chrome-${{ github.sha }}
                   path: |
                       packages/extension/dist
-                      !web-ext-artifacts
-                      !*.xpi
-                      !*.zip
+                      !packages/extension/dist/web-ext-artifacts
+                      !packages/extension/dist/*.xpi
                   if-no-files-found: error

--- a/.github/workflows/build-web-extension.yml
+++ b/.github/workflows/build-web-extension.yml
@@ -3,15 +3,15 @@ name: Build Web Extension
 on:
     workflow_dispatch:
         inputs:
-            server_url_variable:
+            environment:
                 type: choice
-                description: "Server URL Variable"
-                default: "LOCAL_PL_SERVER_URL"
+                description: "Environment to build for"
+                default: "Local"
                 required: true
                 options:
-                    - "LOCAL_PL_SERVER_URL"
-                    - "BETA_PL_SERVER_URL"
-                    - "PRODUCTION_PL_SERVER_URL"
+                    - "Local"
+                    - "Beta"
+                    - "Production"
 
     push:
         branches:
@@ -26,12 +26,10 @@ on:
         #     - "packages/extension/**"
         #     - "packages/locale/**"
 
-env:
-    PL_SERVER_URL: ${{ secrets[github.event.inputs.server_url_variable || 'LOCAL_PL_SERVER_URL'] || '' }}
-
 jobs:
     archive:
         runs-on: ubuntu-latest
+        environment: ${{ github.event.inputs.environment || 'Local' }}
         steps:
             - uses: actions/checkout@v2
             - uses: actions/setup-node@v1
@@ -42,16 +40,15 @@ jobs:
                   npm ci
                   npm i -g web-ext@6.6.0
             - name: Build
-              run: PL_SERVER_URL=${{ env.PL_SERVER_URL }} npm run web-extension:build
-            # TODO: Disabled until the secrets are added
-            # - name: Sign for Firefox
-            #   run: cd packages/extension/dist && web-ext sign --api-key=${{ secrets.WEB_EXT_API_KEY }} --api-secret=${{ secrets.WEB_EXT_API_SECRET }}
-            # - name: Archive Signed Web Extension (Firefox)
-            #   uses: actions/upload-artifact@v2
-            #   with:
-            #       name: signed-web-extension-firefox-${{ github.sha }}
-            #       path: packages/extension/dist/*.xpi
-            #       if-no-files-found: error
+              run: PL_SERVER_URL=${{ secrets.PL_SERVER_URL }} npm run web-extension:build
+            - name: Sign for Firefox
+              run: cd packages/extension/dist && web-ext sign --channel=unlisted --api-key=${{ secrets.PL_WEB_EXTENSION_FIREFOX_API_KEY }} --api-secret=${{ secrets.PL_WEB_EXTENSION_FIREFOX_API_SECRET }}
+            - name: Archive Signed Web Extension (Firefox)
+              uses: actions/upload-artifact@v2
+              with:
+                  name: signed-web-extension-firefox-${{ github.sha }}
+                  path: packages/extension/dist/*.xpi
+                  if-no-files-found: error
             - name: Archive Unsigned Web Extension (Chrome)
               uses: actions/upload-artifact@v2
               with:

--- a/.github/workflows/build-web-extension.yml
+++ b/.github/workflows/build-web-extension.yml
@@ -40,7 +40,7 @@ jobs:
             #     path: *.xpi
             #     if-no-files-found: error
             - name: Zip for Chrome
-              run: cd packages/extension/dist && zip chrome.zip . -x "*.xpi"
+              run: cd packages/extension && zip -r -j chrome.zip dist -x "*.xpi"
             - name: Archive Unsigned Extension (Chrome)
               uses: actions/upload-artifact@v2
               with:

--- a/.github/workflows/build-web-extension.yml
+++ b/.github/workflows/build-web-extension.yml
@@ -4,14 +4,7 @@ on:
     workflow_dispatch:
         inputs:
             environment:
-                type: choice
-                description: "Environment to build for"
-                default: "Local"
-                required: true
-                options:
-                    - "Local"
-                    - "Beta"
-                    - "Production"
+                type: environment
 
     push:
         branches:
@@ -28,7 +21,7 @@ on:
 jobs:
     archive:
         runs-on: ubuntu-latest
-        environment: ${{ github.event.inputs.environment || 'Local' }}
+        environment: ${{ github.event.inputs.environment || "Local" }}
         steps:
             - uses: actions/checkout@v2
             - uses: actions/setup-node@v1

--- a/.github/workflows/build-web-extension.yml
+++ b/.github/workflows/build-web-extension.yml
@@ -9,11 +9,12 @@ on:
             - "master"
             - "feature/**"
             - "fix/**"
-        paths:
-            - "packages/app/**"
-            - "packages/core/**"
-            - "packages/extension/**"
-            - "packages/locale/**"
+        # TODO: Disabled so it can be tested before making code changes
+        # paths:
+        #     - "packages/app/**"
+        #     - "packages/core/**"
+        #     - "packages/extension/**"
+        #     - "packages/locale/**"
 
 jobs:
     archive:
@@ -29,6 +30,7 @@ jobs:
                   npm i -g web-ext@6.6.0
             - name: Build
               run: npm run web-extension:build
+            # TODO: Disabled until the secrets are added
             # - name: Sign for Firefox
             #   run: cd packages/extension/dist && web-ext sign --api-key=${{ secrets.WEB_EXT_API_KEY }} --api-secret=${{ secrets.WEB_EXT_API_SECRET }}
             # - name: Archive Signed Extension (Firefox)

--- a/.github/workflows/build-web-extension.yml
+++ b/.github/workflows/build-web-extension.yml
@@ -2,6 +2,16 @@ name: Build Web Extension
 
 on:
     workflow_dispatch:
+        inputs:
+            server_url_variable:
+                type: choice
+                description: "Server URL Variable"
+                default: "LOCAL_PL_SERVER_URL"
+                required: true
+                options:
+                    - "LOCAL_PL_SERVER_URL"
+                    - "BETA_PL_SERVER_URL"
+                    - "PRODUCTION_PL_SERVER_URL"
 
     push:
         branches:
@@ -16,6 +26,9 @@ on:
         #     - "packages/extension/**"
         #     - "packages/locale/**"
 
+env:
+    PL_SERVER_URL: ${{ secrets[github.event.inputs.server_url_variable || 'LOCAL_PL_SERVER_URL'] || '' }}
+
 jobs:
     archive:
         runs-on: ubuntu-latest
@@ -29,7 +42,7 @@ jobs:
                   npm ci
                   npm i -g web-ext@6.6.0
             - name: Build
-              run: npm run web-extension:build
+              run: PL_SERVER_URL=${{ env.PL_SERVER_URL }} npm run web-extension:build
             # TODO: Disabled until the secrets are added
             # - name: Sign for Firefox
             #   run: cd packages/extension/dist && web-ext sign --api-key=${{ secrets.WEB_EXT_API_KEY }} --api-secret=${{ secrets.WEB_EXT_API_SECRET }}
@@ -44,6 +57,6 @@ jobs:
               with:
                   name: unsigned-web-extension-chrome-${{ github.sha }}
                   path: |
-                    packages/extension/dist
-                    !*.xpi
+                      packages/extension/dist
+                      !*.xpi
                   if-no-files-found: error

--- a/.github/workflows/build-web-extension.yml
+++ b/.github/workflows/build-web-extension.yml
@@ -21,7 +21,7 @@ on:
 jobs:
     archive:
         runs-on: ubuntu-latest
-        environment: ${{ github.event.inputs.environment || "Local' }}
+        environment: ${{ github.event.inputs.environment || 'Local' }}
         steps:
             - uses: actions/checkout@v2
             - uses: actions/setup-node@v1

--- a/.github/workflows/build-web-extension.yml
+++ b/.github/workflows/build-web-extension.yml
@@ -1,4 +1,4 @@
-name: Build Web Extensions
+name: Build Web Extension
 
 on:
     workflow_dispatch:
@@ -12,11 +12,11 @@ on:
             - "master"
             - "feature/**"
             - "fix/**"
-        # paths:
-        #     - "packages/app/**"
-        #     - "packages/core/**"
-        #     - "packages/extension/**"
-        #     - "packages/locale/**"
+        paths:
+            - "packages/app/**"
+            - "packages/core/**"
+            - "packages/extension/**"
+            - "packages/locale/**"
 
 jobs:
     archive:

--- a/.github/workflows/build-web-extension.yml
+++ b/.github/workflows/build-web-extension.yml
@@ -1,0 +1,45 @@
+name: Build Web Extension
+
+on:
+    workflow_dispatch:
+
+    push:
+        branches:
+            - "v4"
+            - "master"
+        paths:
+            - "packages/app/**"
+            - "packages/core/**"
+            - "packages/extension/**"
+            - "packages/locale/**"
+
+jobs:
+    test:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - uses: actions/setup-node@v1
+              with:
+                  node-version: 16.13.1
+            - name: Install dependencies
+              run: |
+                  npm ci
+                  npm i -g web-ext@6.6.0
+            - name: Build
+              run: npm run web-extension:build
+            # - name: Sign for Firefox
+            #   run: cd packages/extension/dist && web-ext sign --api-key=${{ secrets.WEB_EXT_API_KEY }} --api-secret=${{ secrets.WEB_EXT_API_SECRET }}
+            # - name: Archive Signed Extension (Firefox)
+            #   uses: actions/upload-artifact@v2
+            #   with:
+            #     name: signed-extension-firefox-${{ github.sha }}.xpi
+            #     path: *.xpi
+            #     if-no-files-found: error
+            - name: Zip for Chrome
+              run: cd packages/extension/dist && zip chrome.zip . -x "*.xpi"
+            - name: Archive Unsigned Extension (Chrome)
+              uses: actions/upload-artifact@v2
+              with:
+                  name: unsigned-extension-chrome-${{ github.sha }}.zip
+                  path: chrome.zip
+                  if-no-files-found: error

--- a/.github/workflows/build-web-extension.yml
+++ b/.github/workflows/build-web-extension.yml
@@ -7,6 +7,8 @@ on:
         branches:
             - "v4"
             - "master"
+            - "feature/**"
+            - "fix/**"
         paths:
             - "packages/app/**"
             - "packages/core/**"
@@ -14,7 +16,7 @@ on:
             - "packages/locale/**"
 
 jobs:
-    test:
+    archive:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v2

--- a/.github/workflows/build-web-extension.yml
+++ b/.github/workflows/build-web-extension.yml
@@ -33,17 +33,17 @@ jobs:
             # TODO: Disabled until the secrets are added
             # - name: Sign for Firefox
             #   run: cd packages/extension/dist && web-ext sign --api-key=${{ secrets.WEB_EXT_API_KEY }} --api-secret=${{ secrets.WEB_EXT_API_SECRET }}
-            # - name: Archive Signed Extension (Firefox)
+            # - name: Archive Signed Web Extension (Firefox)
             #   uses: actions/upload-artifact@v2
             #   with:
-            #     name: signed-extension-firefox-${{ github.sha }}.xpi
-            #     path: *.xpi
-            #     if-no-files-found: error
-            - name: Zip for Chrome
-              run: cd packages/extension && zip -r -j chrome.zip dist -x "*.xpi"
-            - name: Archive Unsigned Extension (Chrome)
+            #       name: signed-web-extension-firefox-${{ github.sha }}
+            #       path: packages/extension/dist/*.xpi
+            #       if-no-files-found: error
+            - name: Archive Unsigned Web Extension (Chrome)
               uses: actions/upload-artifact@v2
               with:
-                  name: unsigned-extension-chrome-${{ github.sha }}.zip
-                  path: packages/extension/chrome.zip
+                  name: unsigned-web-extension-chrome-${{ github.sha }}
+                  path: |
+                    packages/extension/dist
+                    !*.xpi
                   if-no-files-found: error

--- a/.github/workflows/build-web-extension.yml
+++ b/.github/workflows/build-web-extension.yml
@@ -19,12 +19,11 @@ on:
             - "master"
             - "feature/**"
             - "fix/**"
-        # TODO: Disabled so it can be tested before making code changes
-        # paths:
-        #     - "packages/app/**"
-        #     - "packages/core/**"
-        #     - "packages/extension/**"
-        #     - "packages/locale/**"
+        paths:
+            - "packages/app/**"
+            - "packages/core/**"
+            - "packages/extension/**"
+            - "packages/locale/**"
 
 jobs:
     archive:

--- a/.github/workflows/build-web-extensions.yml
+++ b/.github/workflows/build-web-extensions.yml
@@ -12,11 +12,11 @@ on:
             - "master"
             - "feature/**"
             - "fix/**"
-        paths:
-            - "packages/app/**"
-            - "packages/core/**"
-            - "packages/extension/**"
-            - "packages/locale/**"
+        # paths:
+        #     - "packages/app/**"
+        #     - "packages/core/**"
+        #     - "packages/extension/**"
+        #     - "packages/locale/**"
 
 jobs:
     archive:
@@ -26,7 +26,7 @@ jobs:
             - uses: actions/checkout@v2
             - uses: actions/setup-node@v2
               with:
-                  node-version-file: '.nvmrc'
+                  node-version-file: ".nvmrc"
             - name: Install dependencies
               run: |
                   npm i -g npm@8.2.0 web-ext@6.6.0

--- a/.github/workflows/build-web-extensions.yml
+++ b/.github/workflows/build-web-extensions.yml
@@ -1,4 +1,4 @@
-name: Build Web Extension
+name: Build Web Extensions
 
 on:
     workflow_dispatch:
@@ -24,13 +24,13 @@ jobs:
         environment: ${{ github.event.inputs.environment || 'Local' }}
         steps:
             - uses: actions/checkout@v2
-            - uses: actions/setup-node@v1
+            - uses: actions/setup-node@v2
               with:
-                  node-version: 16.13.1
+                  node-version-file: '.nvmrc'
             - name: Install dependencies
               run: |
+                  npm i -g npm@8.2.0 web-ext@6.6.0
                   npm ci
-                  npm i -g web-ext@6.6.0
             - name: Build
               run: PL_SERVER_URL=${{ secrets.PL_SERVER_URL }} npm run web-extension:build
             - name: Sign for Firefox

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
-app/src/core/*.js
+packages/app/src/core/*.js
+packages/extension/dist/**/*
 package-lock.json

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
         "server:start": "lerna run start --scope @padloc/server --stream",
         "server:start-dry": "lerna run start-dry --stream --scope @padloc/server",
         "electron:build": "cd packages/electron && npm run build && cd ../..",
+        "web-extension:build": "lerna run build --scope @padloc/extension",
         "start": "npm run pwa:build && lerna run --scope '@padloc/{server,pwa}' --parallel start",
         "dev": "lerna run --parallel --scope '@padloc/{server,pwa}' --parallel dev",
         "tauri:dev": "lerna run --parallel --scope '@padloc/{server,tauri}' --parallel dev",


### PR DESCRIPTION
This PR/branch implements the automatic building + archiving of the Web Extension (for Firefox and Chrome).

It won't publish to the stores just yet (I'd rather that be a separate, manually triggered GH action, that downloads one of the built artifacts and publishes it), and for now Firefox is disabled, until we have the secrets set in GitHub.

Related to #330