### PR TITLE
Add setting for disabling/enabling badge on extension icon

### DIFF
--- a/packages/app/src/elements/icon.ts
+++ b/packages/app/src/elements/icon.ts
@@ -537,6 +537,10 @@ export class PlIcon extends LitElement {
             :host([icon="checkbox-unchecked"]) > div::before {
                 content: "\\f0c8";
             }
+
+            :host([icon="extension"]) > div::before {
+                content: "\\e231";
+            }
         `,
     ];
 

--- a/packages/app/src/elements/settings-extension.ts
+++ b/packages/app/src/elements/settings-extension.ts
@@ -6,21 +6,16 @@ import { router } from "../globals";
 import { translate as $l } from "@padloc/locale/src/translate";
 import { customElement, query } from "lit/decorators.js";
 import { shared } from "../styles";
-import { Select } from "./select";
-import { Settings } from "@padloc/core/src/app";
 import { ToggleButton } from "./toggle-button";
 import "./popover";
 import "./icon";
 
-@customElement("pl-settings-display")
-export class SettingsDisplay extends StateMixin(LitElement) {
+@customElement("pl-settings-extension")
+export class SettingsExtension extends StateMixin(LitElement) {
     static styles = [shared];
 
-    @query("#themeSelect")
-    private _themeSelect: Select<Settings["theme"]>;
-
-    @query("#faviconsButton")
-    private _faviconsButton: ToggleButton;
+    @query("#badgeButton")
+    private _badgeButton: ToggleButton;
 
     connectedCallback() {
         super.connectedCallback();
@@ -29,8 +24,7 @@ export class SettingsDisplay extends StateMixin(LitElement) {
 
     private _updateSettings() {
         this.app.setSettings({
-            theme: this._themeSelect.value || undefined,
-            favicons: this._faviconsButton.active,
+            extensionBadge: this._badgeButton.active,
         });
     }
 
@@ -41,29 +35,18 @@ export class SettingsDisplay extends StateMixin(LitElement) {
                     <pl-button class="transparent slim back-button" @click=${() => router.go("settings")}>
                         <pl-icon icon="backward"></pl-icon>
                     </pl-button>
-                    <pl-icon icon="display" class="left-margined vertically-padded wide-only"></pl-icon>
-                    <div class="padded stretch ellipsis">${$l("Display")}</div>
+                    <pl-icon icon="extension" class="left-margined vertically-padded wide-only"></pl-icon>
+                    <div class="padded stretch ellipsis">${$l("Extension")}</div>
                 </header>
 
                 <pl-scroller class="stretch">
                     <div class="double-margined box">
-                        <h2 class="padded uppercase bg-dark border-bottom semibold">${$l("Theme")}</h2>
-
-                        <pl-select
-                            class="transparent"
-                            .options=${[{ value: "auto" }, { value: "light" }, { value: "dark" }]}
-                            id="themeSelect"
-                            .value=${this.state.settings.theme as any}
-                        ></pl-select>
-                    </div>
-
-                    <div class="double-margined box">
                         <h2 class="padded bg-dark border-bottom semibold horizontal center-aligning layout">
-                            <div class="uppercase stretch">${$l("Favicons")}</div>
+                            <div class="uppercase stretch">${$l("Badge")}</div>
                             <pl-icon icon="info-round" class="subtle"></pl-icon>
                             <pl-popover trigger="hover" class="small double-padded regular" style="max-width: 20em">
                                 ${$l(
-                                    "If this option is enabled, Padloc will automatically load and display website icons for vault items that have at least one URL field."
+                                    "If this option is enabled, the extension icon will show a badge with the number of matching items (if any) for the currently active tab. NOTE: Changing this setting can take up to a minute to take effect."
                                 )}
                             </pl-popover>
                         </h2>
@@ -71,9 +54,9 @@ export class SettingsDisplay extends StateMixin(LitElement) {
                         <div>
                             <pl-toggle-button
                                 class="transparent"
-                                id="faviconsButton"
-                                .active=${this.state.settings.favicons}
-                                .label=${$l("Enable Favicons")}
+                                id="badgeButton"
+                                .active=${this.state.settings.extensionBadge}
+                                .label=${$l("Enable Badge")}
                                 reverse
                             >
                             </pl-toggle-button>

--- a/packages/app/src/elements/settings.ts
+++ b/packages/app/src/elements/settings.ts
@@ -1,5 +1,5 @@
 import { translate as $l } from "@padloc/locale/src/translate";
-import { composeEmail, getPlatform } from "@padloc/core/src/platform";
+import { composeEmail } from "@padloc/core/src/platform";
 import { app, router } from "../globals";
 import { StateMixin } from "../mixins/state";
 import { View } from "./view";

--- a/packages/app/src/elements/settings.ts
+++ b/packages/app/src/elements/settings.ts
@@ -1,5 +1,5 @@
 import { translate as $l } from "@padloc/locale/src/translate";
-import { composeEmail } from "@padloc/core/src/platform";
+import { composeEmail, getPlatform } from "@padloc/core/src/platform";
 import { app, router } from "../globals";
 import { StateMixin } from "../mixins/state";
 import { View } from "./view";
@@ -17,15 +17,21 @@ import "./settings-tools";
 import "./settings-account";
 import "./settings-display";
 import "./settings-billing";
+import "./settings-extension";
 
 @customElement("pl-settings")
 export class Settings extends StateMixin(Routing(View)) {
     readonly routePattern = /^settings(?:\/(\w+))?/;
 
-    private readonly _pages = ["", "account", "security", "display", "about", "tools", "billing"];
+    private readonly _pages = ["", "account", "security", "display", "about", "tools", "billing", "extension"];
 
     @state()
     private _page?: string;
+
+    private get _isWebExtension() {
+        // Not very clean, but it'll do for now
+        return this.app.state.device.description.includes("extension");
+    }
 
     handleRoute([page]: [string]) {
         if (page && !this._pages.includes(page)) {
@@ -136,6 +142,16 @@ export class Settings extends StateMixin(Routing(View)) {
                                 <div
                                     role="link"
                                     class="double-padded center-aligning spacing horizontal layout list-item click hover"
+                                    aria-selected=${this._page === "extension"}
+                                    @click=${() => this.go("settings/extension")}
+                                    ?hidden=${!this._isWebExtension}
+                                >
+                                    <pl-icon icon="extension"></pl-icon>
+                                    <div class="stretch ellipsis">${$l("Extension")}</div>
+                                </div>
+                                <div
+                                    role="link"
+                                    class="double-padded center-aligning spacing horizontal layout list-item click hover"
                                     aria-selected=${this._page === "about"}
                                     @click=${() => this.go("settings/about")}
                                     hidden
@@ -176,6 +192,11 @@ export class Settings extends StateMixin(Routing(View)) {
                     <pl-settings-display class="fullbleed" ?hidden=${this._page !== "display"}></pl-settings-display>
 
                     <pl-settings-billing class="fullbleed" ?hidden=${this._page !== "billing"}></pl-settings-billing>
+
+                    <pl-settings-extension
+                        class="fullbleed"
+                        ?hidden=${this._page !== "extension"}
+                    ></pl-settings-extension>
                 </div>
             </div>
         `;

--- a/packages/core/src/app.ts
+++ b/packages/core/src/app.ts
@@ -55,6 +55,8 @@ export class Settings extends Serializable {
     theme: "dark" | "light" | "auto" = "auto";
     /** Toggle favicons */
     favicons = true;
+    /** Enable badge on web extension icon */
+    extensionBadge = true;
 }
 
 export interface HashedItem {

--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -136,7 +136,7 @@ class ExtensionBackground {
 
     private async _updateBadge() {
         const count = await this._getCountForTab();
-        browser.browserAction.setBadgeText({ text: count ? count.toString() : "" });
+        browser.browserAction.setBadgeText({ text: count && this.app.settings.extensionBadge ? count.toString() : "" });
         browser.browserAction.setBadgeBackgroundColor({ color: "#ff6666" });
     }
 


### PR DESCRIPTION
Title says it all. Setting can be found under Settings/Extension.
<img width="372" alt="Screenshot 2021-12-26 at 11 43 18" src="https://user-images.githubusercontent.com/1270940/147405716-05589a2a-9631-4b6c-be33-c31f28c97842.png">
 