### PR TITLE
Better preserve context in extension when closing/opening popup

### DIFF
--- a/packages/app/src/elements/app.ts
+++ b/packages/app/src/elements/app.ts
@@ -63,7 +63,7 @@ export class App extends ServiceWorker(StateMixin(AutoSync(ErrorHandling(AutoLoc
     ];
 
     @state()
-    private _page: string = "start";
+    protected _page: string = "start";
 
     @state()
     private _menuOpen: boolean = false;

--- a/packages/app/src/elements/items-list.ts
+++ b/packages/app/src/elements/items-list.ts
@@ -450,6 +450,14 @@ export class ItemsList extends StateMixin(LitElement) {
         this._listItems = this._getItems();
     }, 50);
 
+    private _updateFilterParam() {
+        const { search, ...params } = router.params;
+        if (this._filterInput.value) {
+            params.search = this._filterInput.value;
+        }
+        router.go(router.path, params, true);
+    }
+
     private get _selectedVault() {
         return (this.filter?.vault && app.getVault(this.filter.vault)) || null;
     }
@@ -481,17 +489,28 @@ export class ItemsList extends StateMixin(LitElement) {
         }
     }
 
-    async search() {
+    async search(val?: string, focus = true) {
         this._filterShowing = true;
         await this.updateComplete;
-        setTimeout(() => this._filterInput.focus(), 100);
+        setTimeout(() => {
+            if (val && val !== this._filterInput.value) {
+                this._filterInput.value = val;
+                this._updateItems();
+            }
+            if (focus) {
+                this._filterInput.focus();
+            }
+        }, 100);
     }
 
     cancelSearch() {
-        this._filterInput.value = "";
-        this._filterInput.blur();
+        if (this._filterInput.value) {
+            this._filterInput.value = "";
+            this._updateFilterParam();
+            this._updateItems();
+        }
         this._filterShowing = false;
-        this._updateItems();
+        this._filterInput.blur();
     }
 
     selectItem(item: ListItem) {
@@ -720,6 +739,7 @@ export class ItemsList extends StateMixin(LitElement) {
                     select-on-focus
                     @input=${this._updateItems}
                     @escape=${this.cancelSearch}
+                    @change=${this._updateFilterParam}
                 >
                     <pl-icon slot="before" class="left-margined left-padded subtle small" icon="search"></pl-icon>
 

--- a/packages/app/src/elements/items.ts
+++ b/packages/app/src/elements/items.ts
@@ -22,7 +22,7 @@ export class ItemsView extends Routing(StateMixin(View)) {
 
     async handleRoute(
         [id]: [string],
-        { vault, tag, favorites, attachments, recent, host }: { [prop: string]: string }
+        { vault, tag, favorites, attachments, recent, host, search }: { [prop: string]: string }
     ) {
         this.filter = {
             vault,
@@ -33,6 +33,14 @@ export class ItemsView extends Routing(StateMixin(View)) {
             host: host === "true",
         };
         this.selected = id;
+
+        if (this.active) {
+            if (search) {
+                this._list?.search(search, false);
+            } else {
+                this._list?.cancelSearch();
+            }
+        }
 
         // WEIRD workaround for a bug that caused problems with drag & drop on fields within the list
         // directly after unlocking the app (appears only in Chrome).

--- a/packages/extension/src/app.ts
+++ b/packages/extension/src/app.ts
@@ -53,7 +53,10 @@ export class ExtensionApp extends App {
             matchingItems.length !== routerState.lastMatchingItems.length ||
             matchingItems.some(({ item }) => !routerState.lastMatchingItems.includes(item.id));
 
-        if (matchingItems.length && (hasNewMatchingItems || routerState.path === "items")) {
+        if (
+            matchingItems.length &&
+            (hasNewMatchingItems || (routerState.path === "items" && !routerState.params.search))
+        ) {
             this.router.go("items", { host: "true" }, true);
             this._saveRouterState();
         } else {

--- a/packages/extension/src/app.ts
+++ b/packages/extension/src/app.ts
@@ -16,8 +16,9 @@ class RouterState extends Storable {
     id = "";
     path = "";
     params: { [key: string]: string } = {};
+    lastMatchingItems: string[] = [];
 
-    constructor(vals: Partial<RouterState>) {
+    constructor(vals: Partial<RouterState> = {}) {
         super();
         Object.assign(this, vals);
     }
@@ -27,11 +28,8 @@ export class ExtensionApp extends App {
     private _isLocked = true;
     private _isLoggedIn = false;
 
-    private get _hasMatchingItems() {
-        return (
-            !!this.app.state.context.browser?.url &&
-            !!this.app.getItemsForUrl(this.app.state.context.browser.url).length
-        );
+    private get _matchingItems() {
+        return this.app.state.context.browser?.url ? this.app.getItemsForUrl(this.app.state.context.browser.url) : [];
     }
 
     async load() {
@@ -49,13 +47,17 @@ export class ExtensionApp extends App {
         const [tab] = await browser.tabs.query({ currentWindow: true, active: true });
         this.app.state.context.browser = tab;
 
-        if (this._hasMatchingItems) {
+        const routerState = await this._getRouterState();
+        const matchingItems = this._matchingItems;
+        const hasNewMatchingItems =
+            matchingItems.length !== routerState.lastMatchingItems.length ||
+            matchingItems.some(({ item }) => !routerState.lastMatchingItems.includes(item.id));
+
+        if (matchingItems.length && (hasNewMatchingItems || routerState.path === "items")) {
             this.router.go("items", { host: "true" }, true);
+            this._saveRouterState();
         } else {
-            try {
-                const routerState = await this.app.storage.get(RouterState, "");
-                this.router.go(routerState.path, routerState.params, true);
-            } catch (e) {}
+            this.router.go(routerState.path, routerState.params, true);
         }
 
         this.router.addEventListener("route-changed", () => this._saveRouterState());
@@ -104,9 +106,9 @@ export class ExtensionApp extends App {
             masterKey: bytesToBase64(this.state.account.masterKey),
         });
 
-        if (this._hasMatchingItems) {
-            this.router.go("items", { host: "true" }, true);
-        }
+        // if (this._hasMatchingItems) {
+        //     this.router.go("items", { host: "true" }, true);
+        // }
     }
 
     _locked() {
@@ -127,9 +129,18 @@ export class ExtensionApp extends App {
         });
     }
 
+    private async _getRouterState() {
+        try {
+            return await this.app.storage.get(RouterState, "");
+        } catch (e) {
+            return new RouterState();
+        }
+    }
+
     private async _saveRouterState() {
         const { host, ...params } = this.router.params;
-        await this.app.storage.save(new RouterState({ path: this.router.path, params }));
+        const lastMatchingItems = this._matchingItems.map(({ item }) => item.id);
+        await this.app.storage.save(new RouterState({ path: this.router.path, params, lastMatchingItems }));
     }
 
     protected async _fieldDragged(e: CustomEvent<{ item: VaultItem; index: number; event: DragEvent }>) {


### PR DESCRIPTION
- Store search string in url when leaving input
- Restore search when navigating to items view and `search` param is set.
- Only redirect to vault items matching current url if there are **new** matching vault items, i.e. if the page context changes.