### PR TITLE
Allow setting a build for web extension beta builds

### DIFF
--- a/.github/workflows/build-web-extension.yml
+++ b/.github/workflows/build-web-extension.yml
@@ -6,6 +6,11 @@ on:
             environment:
                 type: environment
                 default: "Local"
+            build:
+                type: string
+                description: "Build number (int, 3 max digits)"
+                default: "0"
+                required: true
 
     push:
         branches:
@@ -35,6 +40,7 @@ jobs:
                   npm ci
             - name: Build
               env:
+                  RELEASE_BUILD: ${{ github.event.inputs.build || '0' }}
                   PL_SERVER_URL: ${{ secrets.PL_SERVER_URL }}
                   PL_BUILD_ENV: ${{ secrets.PL_BUILD_ENV }}
               run: npm run web-extension:build


### PR DESCRIPTION
This prevents the error seen in https://github.com/padloc/padloc/runs/4899240160?check_suite_focus=true (`Version already exists. Latest version is: 4.0.0.x. (status: 409)`)

This happens because we removed the logic of generating a random build, which was unnecessary, but forgot to add the option to this CI job.