### PR TITLE
Find Item end-to-end test

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -4,5 +4,6 @@
     "video": false,
     "chromeWebSecurity": false,
     "screenshotOnRunFailure": false,
-    "videoUploadOnPasses": false
+    "videoUploadOnPasses": false,
+    "waitForAnimations": true
 }

--- a/cypress/integration/02 - items.ts
+++ b/cypress/integration/02 - items.ts
@@ -24,7 +24,7 @@ describe("Items", () => {
         cy.url().should("include", "/new");
 
         // Give the app some time to finish animations
-        cy.wait(100);
+        cy.wait(200);
 
         // Fill in form
         cy.get("pl-app")

--- a/cypress/integration/02 - items.ts
+++ b/cypress/integration/02 - items.ts
@@ -5,24 +5,23 @@ const testItem = {
     url: "https://google.com",
 };
 
+const itemSearch = {
+    existing: "secret",
+    nonexistent: "apple",
+};
+
 describe("Items", () => {
     it("can create an item without errors", () => {
         cy.login();
 
         // Click plus sign
-        cy.get("pl-app").find("pl-items").find("pl-items-list").find("pl-button:eq(2)").click({ force: true });
-
-        // Give the app some time to render the animations
-        cy.wait(100);
+        cy.get("pl-app").find("pl-items").find("pl-items-list").find("pl-button:eq(2)").click();
 
         // Click create
-        cy.get("pl-app").find("pl-create-item-dialog").find("footer pl-button.primary").click({ force: true });
+        cy.get("pl-app").find("pl-create-item-dialog").find("footer pl-button.primary").click();
 
         cy.url().should("include", "/items/");
         cy.url().should("include", "/new");
-
-        // Give the app some (more) time to render the animations
-        cy.wait(100);
 
         // Fill in form
         cy.get("pl-app")
@@ -34,35 +33,96 @@ describe("Items", () => {
         cy.get("pl-app")
             .find("pl-items")
             .find("pl-item-view")
-            .find("pl-scroller")
-            .find("pl-list")
-            .find("pl-field:eq(0)")
+            .find("pl-scroller pl-list pl-field:eq(0)")
             .find("pl-input.value-input")
             .find("input.input-element")
             .type(testItem.username, { force: true });
         cy.get("pl-app")
             .find("pl-items")
             .find("pl-item-view")
-            .find("pl-scroller")
-            .find("pl-list")
-            .find("pl-field:eq(1)")
+            .find("pl-scroller pl-list pl-field:eq(1)")
             .find("pl-input.value-input")
             .find("input.input-element")
             .type(testItem.password, { force: true });
         cy.get("pl-app")
             .find("pl-items")
             .find("pl-item-view")
-            .find("pl-scroller")
-            .find("pl-list")
-            .find("pl-field:eq(2)")
+            .find("pl-scroller pl-list pl-field:eq(2)")
             .find("pl-input.value-input")
             .find("input.input-element")
             .type(testItem.url, { force: true });
 
         // Click save
-        cy.get("pl-app").find("pl-items").find("pl-item-view").find("pl-button.primary").click({ force: true });
+        cy.get("pl-app").find("pl-items").find("pl-item-view").find("pl-button.primary").click();
 
         cy.url().should("include", "/items/");
         cy.url().should("not.include", "/new");
+    });
+
+    it("can find an an item without errors", () => {
+        cy.unlock();
+
+        // Click search sign
+        cy.get("pl-app").find("pl-items").find("pl-items-list").find("pl-button:eq(3)").click();
+
+        // Find Item
+        cy.get("pl-app")
+            .find("pl-items")
+            .find("pl-items-list")
+            .find("pl-input#filterInput")
+            .find("input")
+            .type(itemSearch.existing, { force: true });
+
+        // Confirm we only find one
+        cy.get("pl-app")
+            .find("pl-items")
+            .find("pl-items-list")
+            .find("main pl-virtual-list pl-scroller")
+            .find("div.content")
+            .children("div")
+            .should("have.length", 1);
+
+        // Confirm we find the right one
+        cy.get("pl-app")
+            .find("pl-items")
+            .find("pl-items-list")
+            .find("main pl-virtual-list pl-scroller")
+            .find("div.content pl-vault-item-list-item")
+            .find("div > div > div.semibold")
+            .should("include.text", testItem.name);
+
+        // Click clear search sign
+        cy.get("pl-app")
+            .find("pl-items")
+            .find("pl-items-list")
+            .find("pl-input#filterInput")
+            .find("pl-button.slim")
+            .click();
+
+        // Click search sign
+        cy.get("pl-app").find("pl-items").find("pl-items-list").find("pl-button:eq(3)").click();
+
+        // Find non-existent Item
+        cy.get("pl-app")
+            .find("pl-items")
+            .find("pl-items-list")
+            .find("pl-input#filterInput")
+            .find("input")
+            .type(itemSearch.nonexistent, { force: true });
+
+        // Confirm we find none
+        cy.get("pl-app")
+            .find("pl-items")
+            .find("pl-items-list")
+            .find("main pl-virtual-list pl-scroller")
+            .find("div.content")
+            .children("div")
+            .should("have.length", 0);
+
+        cy.get("pl-app")
+            .find("pl-items")
+            .find("pl-items-list")
+            .find("main > div.centering")
+            .should("contain.text", "did not match any items");
     });
 });

--- a/cypress/integration/02 - items.ts
+++ b/cypress/integration/02 - items.ts
@@ -23,6 +23,9 @@ describe("Items", () => {
         cy.url().should("include", "/items/");
         cy.url().should("include", "/new");
 
+        // Give the app some time to finish animations
+        cy.wait(100);
+
         // Fill in form
         cy.get("pl-app")
             .find("pl-items")
@@ -64,6 +67,9 @@ describe("Items", () => {
 
         // Click search sign
         cy.get("pl-app").find("pl-items").find("pl-items-list").find("pl-button:eq(3)").click();
+
+        // Give the app some time to finish animations
+        cy.wait(100);
 
         // Find Item
         cy.get("pl-app")

--- a/cypress/integration/02 - items.ts
+++ b/cypress/integration/02 - items.ts
@@ -24,7 +24,7 @@ describe("Items", () => {
         cy.url().should("include", "/new");
 
         // Give the app some time to finish animations
-        cy.wait(200);
+        cy.wait(300);
 
         // Fill in form
         cy.get("pl-app")

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -67,7 +67,7 @@ Cypress.Commands.add("signup", () => {
     cy.get("pl-app").find("pl-start").find("pl-login-signup").find("pl-button:eq(2)").click({ force: true });
 
     // Give the app some time to finish animations
-    cy.wait(100);
+    cy.wait(200);
 
     // Choose a different password
     cy.get("pl-app")
@@ -78,13 +78,13 @@ Cypress.Commands.add("signup", () => {
         .click({ force: true });
 
     // Give the app some time to finish animations
-    cy.wait(100);
+    cy.wait(200);
 
     // Choose my own
     cy.get("pl-app").find("pl-alert-dialog").find("pl-button:eq(2)").click({ force: true });
 
     // Give the app some time to finish animations
-    cy.wait(100);
+    cy.wait(200);
 
     // Type master password
     cy.get("pl-app")
@@ -97,10 +97,13 @@ Cypress.Commands.add("signup", () => {
     cy.get("pl-app").find("pl-prompt-dialog").find("pl-button#confirmButton").click({ force: true });
 
     // Give the app some time to render the alert, otherwise it sometimes shows out of place
-    cy.wait(100);
+    cy.wait(200);
 
     // Confirm weak password
     cy.get("pl-app").find("pl-alert-dialog").find("pl-button:eq(1)").click({ force: true });
+
+    // Give the app some time to finish animations
+    cy.wait(100);
 
     // Continue signup
     cy.get("pl-app")

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -28,14 +28,23 @@ Cypress.Commands.add("signup", () => {
         .find("pl-button#submitEmailButton")
         .click({ force: true });
 
+    // Give the app some time to finish animations
+    cy.wait(100);
+
     cy.get("pl-app")
         .find("pl-prompt-dialog")
         .find("pl-input")
         .find("input[placeholder='Enter Verification Code']")
         .type(emailToken, { force: true });
 
+    // Give the app some time to finish animations
+    cy.wait(100);
+
     // Confirm token
     cy.get("pl-app").find("pl-prompt-dialog").find("pl-button#confirmButton").click({ force: true });
+
+    // Give the app some time to finish animations
+    cy.wait(100);
 
     // Enter name
     cy.get("pl-app")
@@ -57,6 +66,9 @@ Cypress.Commands.add("signup", () => {
     // Continue
     cy.get("pl-app").find("pl-start").find("pl-login-signup").find("pl-button:eq(2)").click({ force: true });
 
+    // Give the app some time to finish animations
+    cy.wait(100);
+
     // Choose a different password
     cy.get("pl-app")
         .find("pl-start")
@@ -65,8 +77,14 @@ Cypress.Commands.add("signup", () => {
         .find("pl-button:eq(1)")
         .click({ force: true });
 
+    // Give the app some time to finish animations
+    cy.wait(100);
+
     // Choose my own
     cy.get("pl-app").find("pl-alert-dialog").find("pl-button:eq(2)").click({ force: true });
+
+    // Give the app some time to finish animations
+    cy.wait(100);
 
     // Type master password
     cy.get("pl-app")


### PR DESCRIPTION
This adds a "find item" e2e test that confirms matching items show, and non-matching items don't.

I also implemented the `waitForAnimations` config setting, but I found the results inconsistent via CLI, so I left the `cy.wait()`s in, after much experimentation.

There are a couple of improvements on reducing the number of `cy.find()` calls in the Cypress tests, when the elements aren't rendered in the Shadow DOM.