### PR TITLE
Enable Auto-lock in web extension

### DIFF
--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -12,9 +12,9 @@ setPlatform(new ExtensionPlatform());
 class ExtensionBackground {
     app = new App(new AjaxSender(process.env.PL_SERVER_URL!));
 
-    _autoLockAlarmName = "pl_autoLock";
+    private _autoLockAlarmName = "pl_autoLock";
 
-    get _lockDelayInMinutes() {
+    private get _lockDelayInMinutes() {
         return this.app.settings.autoLockDelay;
     }
 
@@ -220,7 +220,7 @@ class ExtensionBackground {
         }
     }
 
-    async _cancelAutoLock() {
+    private async _cancelAutoLock() {
         await browser.alarms.clear(this._autoLockAlarmName);
     }
 

--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -12,6 +12,12 @@ setPlatform(new ExtensionPlatform());
 class ExtensionBackground {
     app = new App(new AjaxSender(process.env.PL_SERVER_URL!));
 
+    _autoLockAlarmName = "pl_autoLock";
+
+    get _lockDelayInMinutes() {
+        return this.app.settings.autoLockDelay;
+    }
+
     // private _currentItemIndex = -1;
 
     private _reload = throttle(async () => {
@@ -24,7 +30,7 @@ class ExtensionBackground {
         this.app.subscribe(update);
         browser.runtime.onMessage.addListener(async (msg: Message, sender: Runtime.MessageSender) => {
             if (sender.tab) {
-                // Communication with content-scripts is one-way, to we ignore
+                // Communication with content-scripts is one-way, so we ignore
                 // messages from them, just to be safe
                 return;
             }
@@ -33,11 +39,13 @@ class ExtensionBackground {
                 case "loggedOut":
                 case "locked":
                     await this.app.load();
+                    this._cancelAutoLock();
                     update();
                     break;
                 case "unlocked":
                     await this.app.load();
                     await this.app.unlockWithMasterKey(base64ToBytes(msg.masterKey));
+                    this._startAutoLockTimer();
                     update();
                     break;
                 case "requestMasterKey":
@@ -58,6 +66,12 @@ class ExtensionBackground {
         browser.contextMenus.onClicked.addListener(({ menuItemId }: Menus.OnClickData) =>
             this._contextMenuClicked(menuItemId as string)
         );
+
+        browser.alarms.onAlarm.addListener((alarm) => {
+            if (alarm.name === this._autoLockAlarmName) {
+                this._doLock();
+            }
+        });
 
         this.app.load();
         // Poll for updates once an hour
@@ -203,6 +217,30 @@ class ExtensionBackground {
         } else {
             browser.browserAction.setIcon({ path: "icon.png" });
             browser.browserAction.setTitle({ title: process.env.PL_APP_NAME || "" });
+        }
+    }
+
+    async _cancelAutoLock() {
+        await browser.alarms.clear(this._autoLockAlarmName);
+    }
+
+    private async _doLock() {
+        // if app is currently syncing restart the timer
+        if (this.app.state.syncing) {
+            this._startAutoLockTimer();
+            return;
+        }
+
+        await this.app.lock();
+        this._reload();
+    }
+
+    private _startAutoLockTimer() {
+        this._cancelAutoLock();
+        if (this.app.settings.autoLock && !this.app.state.locked) {
+            browser.alarms.create(this._autoLockAlarmName, {
+                delayInMinutes: this._lockDelayInMinutes,
+            });
         }
     }
 }

--- a/packages/extension/src/manifest.json
+++ b/packages/extension/src/manifest.json
@@ -11,7 +11,7 @@
         "default_popup": "popup.html",
         "default_icon": "icon.png"
     },
-    "permissions": ["storage", "unlimitedStorage", "tabs", "activeTab", "contextMenus"],
+    "permissions": ["storage", "unlimitedStorage", "tabs", "activeTab", "contextMenus", "alarms"],
     "commands": {
         "_execute_browser_action": {
             "suggested_key": {


### PR DESCRIPTION
This allows the web extension to auto-lock (tested in Chrome and Firefox), by running an alarm in the background, since the `setTimeout` is ignored past 10 seconds.

I noticed that if the popup is open, it does not lock until it’s closed (even after firing the alarm). I couldn’t find a way to change the route for the app from the background, and I wasn’t sure if it would worth it adding a new listener for this, as it’s not common for the extension to be open for a long period of time anyway.

Closes #300