### PR TITLE
Add support for .env file to server package; update readme files

### DIFF
--- a/.github/workflows/build-tauri.yml
+++ b/.github/workflows/build-tauri.yml
@@ -52,14 +52,14 @@ jobs:
                   npm ci
             - name: Build (debug)
               if: github.event.inputs.environment != 'Production'
-              run: npm run tauri:build
+              run: npm run tauri:build:debug
               env:
                   PL_SERVER_URL: ${{ secrets.PL_SERVER_URL }}
                   TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
                   TAURI_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
             - name: Build (production)
               if: github.event.inputs.environment == 'Production'
-              run: npm run tauri:build:production
+              run: npm run tauri:build
               env:
                   PL_SERVER_URL: ${{ secrets.PL_SERVER_URL }}
                   TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -4,5 +4,13 @@
     "semi": true,
     "singleQuote": false,
     "bracketSpacing": true,
-    "proseWrap": "always"
+    "overrides": [
+        {
+            "files": "**/*.md",
+            "options": {
+                "printWidth": 80,
+                "proseWrap": "always"
+            }
+        }
+    ]
 }

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -3,5 +3,6 @@
     "tabWidth": 4,
     "semi": true,
     "singleQuote": false,
-    "bracketSpacing": true
+    "bracketSpacing": true,
+    "proseWrap": "always"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,8 +3,6 @@
     "files.associations": {
         "*.svg": "html"
     },
-    "editor.formatOnSave": true,
-    "csscomb.formatOnSave": true,
     "prettier.prettierPath": "./node_modules/prettier",
     "files.insertFinalNewline": true
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,7 @@
         "*.svg": "html"
     },
     "editor.formatOnSave": true,
-    "csscomb.formatOnSave": true
+    "csscomb.formatOnSave": true,
+    "prettier.prettierPath": "./node_modules/prettier",
+    "files.insertFinalNewline": true
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,7 @@
     "lit-plugin.globalAttributes": ["disabled"],
     "files.associations": {
         "*.svg": "html"
-    }
+    },
+    "editor.formatOnSave": true,
+    "csscomb.formatOnSave": true
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
-and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+and this project adheres to
+[Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## 3.1.2
 
@@ -22,18 +23,23 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -   Improved flow for creating a vault item
 -   If a vault filter is active, preselect that vault during vault item creation
 -   Prefill field names with sensible default when adding new field
--   Automated account migration if legacy account is detected during login/signup
+-   Automated account migration if legacy account is detected during
+    login/signup
 -   "Login" vault item template is now called "Website / App"
 -   Added new vault item template "Computer"
--   [DESKTOP] Ctrl/cmd + Shift + F to search all items (resetting any active filters)
+-   [DESKTOP] Ctrl/cmd + Shift + F to search all items (resetting any active
+    filters)
 -   [ANDROID] Allow reordering fields via drag and drop on Android
--   [SERVER] Option to enable secure connection when sending emails, enabled via `PL_EMAIL_SECURE` environment variable
+-   [SERVER] Option to enable secure connection when sending emails, enabled via
+    `PL_EMAIL_SECURE` environment variable
 
 ### Bug Fixes
 
 -   Sometimes the app would show a blank screen directly after unlocking.
--   Changes made to a vault item directly after creating it would sometimes be discarded.
+-   Changes made to a vault item directly after creating it would sometimes be
+    discarded.
 
 ## 3.0.0
 
-Initial release of Padloc 3 (changes before 3.0.0 are not included in this change log).
+Initial release of Padloc 3 (changes before 3.0.0 are not included in this
+change log).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,661 @@
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<https://www.gnu.org/licenses/>.

--- a/README.md
+++ b/README.md
@@ -8,24 +8,26 @@ Simple, secure password and data management for individuals and teams.
 
 This repo is split into multiple packages:
 
-| Package Name                            | Description                                                                                                                               |
-| --------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| [@padloc/core](packages/core)           | Core Logic                                                                                                                                |
-| [@padloc/app](packages/app)             | Web-based UI components                                                                                                                   |
-| [@padloc/server](packages/server)       | The Backend Server                                                                                                                        |
-| [@padloc/pwa](packages/pwa)             | The Web Client, a [Progressive Web App](https://developers.google.com/web/progressive-web-apps) built on top of the `@padloc/app` package |
-| [@padloc/locale](packages/locale)       | Package containing translations and other localization-related things                                                                     |
-| [@padloc/electron](packages/electron)   | The Desktop App, built with Electron                                                                                                      |
-| [@padloc/cordova](packages/cordova)     | Cordova project for building iOS and Android app.                                                                                         |
-| [@padloc/tauri](packages/tauri)         | Cross-platform native app builder for Padloc, powered by [Tauri](https://github.com/tauri-apps/tauri)                                     |
-| [@padloc/extension](packages/extension) | Padloc browser extension                                                                                                                  |
+| Package Name                            | Description                                                                                      |
+| --------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| [@padloc/core](packages/core)           | Core Logic                                                                                       |
+| [@padloc/app](packages/app)             | Web-based UI components                                                                          |
+| [@padloc/server](packages/server)       | The Backend Server                                                                               |
+| [@padloc/pwa](packages/pwa)             | The Web Client, a [Progressive Web App](https://developers.google.com/web/progressive-web-apps). |
+| [@padloc/locale](packages/locale)       | Package containing translations and other localization-related things                            |
+| [@padloc/electron](packages/electron)   | The Desktop App, built with Electron                                                             |
+| [@padloc/cordova](packages/cordova)     | Cordova project for building iOS and Android app.                                                |
+| [@padloc/tauri](packages/tauri)         | Cross-platform native app, powered by [Tauri](https://github.com/tauri-apps/tauri)               |
+| [@padloc/extension](packages/extension) | Padloc browser extension                                                                         |
 
 ## How to use
 
-As you can see in the [About](#about) section, there are lots of different components to play with! But at a minimum, in
-order to set up and use your own instance of Padloc you'll need to install and configure the [Server](packages/server)
-and [Web Client](packages/pwa). In practice, there a few different ways to do this, but if you just want to install and
-test Padloc locally, doing so is really quite easy:
+As you can see in the [About](#about) section, there are lots of different
+components to play with! But at a minimum, in order to set up and use your own
+instance of Padloc you'll need to install and configure the
+[Server](packages/server) and [Web Client](packages/pwa). In practice, there a
+few different ways to do this, but if you just want to install and test Padloc
+locally, doing so is really quite easy:
 
 ```sh
 git clone git@github.com:padloc/padloc.git
@@ -36,8 +38,9 @@ npm start
 
 The web client is now available at `http://localhost:8080`!
 
-In-depth guides on how to host your own "productive" version of Padloc and how to build and distribute your own versions
-of the desktop and mobile apps are coming soon!
+In-depth guides on how to host your own "productive" version of Padloc and how
+to build and distribute your own versions of the desktop and mobile apps are
+coming soon!
 
 ## Contributing
 
@@ -49,16 +52,20 @@ If you want to **report a bug or have a feature request**, please
 If you **have question, feedback or would just like to chat**, head over to the
 [discussions](https://github.com/padloc/padloc/discussions) section.
 
-If you want to **contribute to Padloc directly** by implementing a new feature or fixing an existing issue, feel free to
-[create a pull request](https://github.com/padloc/padloc/pulls)! However if you plan to work on anything non-trivial,
-please do talk to us first, either by commenting on an existing issue, creating a new issue or by pinging us in the
+If you want to **contribute to Padloc directly** by implementing a new feature
+or fixing an existing issue, feel free to
+[create a pull request](https://github.com/padloc/padloc/pulls)! However if you
+plan to work on anything non-trivial, please do talk to us first, either by
+commenting on an existing issue, creating a new issue or by pinging us in the
 dissusions section!
 
-To learn how to get started working on Padloc, refer to the [Development](#development) section of the readme.
+To learn how to get started working on Padloc, refer to the
+[Development](#development) section of the readme.
 
 ## Security
 
-For a security design overview, check out the [security whitepaper](security.md).
+For a security design overview, check out the
+[security whitepaper](security.md).
 
 ## Development
 
@@ -82,23 +89,27 @@ To start "dev mode", simply run
 npm run dev
 ```
 
-from the root of the project. This will start the backend server (by default listening on port `3000`), as well as the
-PWA (available on `http://localhost:8080`) by default.
+from the root of the project. This will start the backend server (by default
+listening on port `3000`), as well as the PWA (available on
+`http://localhost:8080`) by default.
 
-The server and PWA port can be changed vie the `PL_TRANSPORT_HTTP_PORT` and `PL_PWA_PORT` environvent variables,
-respectively. For more configuration options, check out the **Conguration** section of the
+The server and PWA port can be changed vie the `PL_TRANSPORT_HTTP_PORT` and
+`PL_PWA_PORT` environvent variables, respectively. For more configuration
+options, check out the **Conguration** section of the
 [server](packages/server#configuration) and [pwa](packages/pwa#configuration).
 
 ### Formatting
 
-This project is formatted with [Prettier](https://prettier.io/). To re-format all files using our
-[.prettierrc.json](.prettierrc.json) specification, run the following from the root of the project.
+This project is formatted with [Prettier](https://prettier.io/). To re-format
+all files using our [.prettierrc.json](.prettierrc.json) specification, run the
+following from the root of the project.
 
 ```sh
 npm run format
 ```
 
-To simply check whether everything is formatted correctly, you can use the following command:
+To simply check whether everything is formatted correctly, you can use the
+following command:
 
 ```sh
 npm run format:check
@@ -126,8 +137,9 @@ npm run test:e2e:dev
 
 ### Adding / removing dependencies
 
-Since this is a monorepo consisting of multiple packages, adding/removing to/from a single package can be less than
-straightforward. The following commands are meant to make this easier.
+Since this is a monorepo consisting of multiple packages, adding/removing
+to/from a single package can be less than straightforward. The following
+commands are meant to make this easier.
 
 To add a dependency to a package, run:
 
@@ -141,22 +153,25 @@ And to remove one:
 scope=[package_name] npm run remove [dependency]
 ```
 
-For example, here is how you would add `typescript` to the `@padloc/server` package:
+For example, here is how you would add `typescript` to the `@padloc/server`
+package:
 
 ```sh
 scope=server npm run add typescript
 ```
 
-**Note**: We're trying to keep the number and size of third-party dependencies to a minumum, so before you add a
-dependency, please think twice if it is really needed! Pull requests with unnecessary dependencies will very likely be
+**Note**: We're trying to keep the number and size of third-party dependencies
+to a minumum, so before you add a dependency, please think twice if it is really
+needed! Pull requests with unnecessary dependencies will very likely be
 rejected.
 
 ### Updating The Version
 
-The Padloc project consists of many different subpackages. To simplify versioning, we use a global version for all them.
-This means that when releasing a new version, the version of all subpackages needs to be updated, regardless of whether
-there have been changes in them or not. To update the global version accross the project, you can use the following
-command:
+The Padloc project consists of many different subpackages. To simplify
+versioning, we use a global version for all them. This means that when releasing
+a new version, the version of all subpackages needs to be updated, regardless of
+whether there have been changes in them or not. To update the global version
+accross the project, you can use the following command:
 
 ```sh
 npm run version [semver_version]
@@ -164,15 +179,20 @@ npm run version [semver_version]
 
 ### Deployment / Publishing
 
-Padloc has a lot of different components that all need to be built/released/published in different ways. To manage this
-complexitiy, we have compiled all deployment steps for all components in a single Github Workflow. To release a new
-version, simply:
+Padloc has a lot of different components that all need to be
+built/released/published in different ways. To manage this complexitiy, we have
+compiled all deployment steps for all components in a single Github Workflow. To
+release a new version, simply:
 
 1. [Update project version](#updating-the-version)
 2. Commit and push.
-3. Run the [`Publish Release`](https://github.com/padloc/padloc/actions?workflow=Publish+Release) action.
+3. Run the
+   [`Publish Release`](https://github.com/padloc/padloc/actions?workflow=Publish+Release)
+   action.
 
 ## Licensing
 
-This software is published under the [GNU Affero General Public License](LICENSE). If you wish to acquire a commercial
-license, please contact us as [sales@padloc.app](mailto:sales@padloc.app?subject=Padloc%20Commercial%20License).
+This software is published under the
+[GNU Affero General Public License](LICENSE). If you wish to acquire a
+commercial license, please contact us as
+[sales@padloc.app](mailto:sales@padloc.app?subject=Padloc%20Commercial%20License).

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ release a new version, simply:
 1. [Update project version](#updating-the-version)
 2. Commit and push.
 3. Run the
-   [`Publish Release`](https://github.com/padloc/padloc/actions?workflow=Publish+Release)
+   [Publish Release](https://github.com/padloc/padloc/actions?workflow=Publish+Release)
    action.
 
 ## Licensing

--- a/README.md
+++ b/README.md
@@ -2,94 +2,177 @@
 
 [![](https://github.com/padloc/padloc/workflows/Run%20Tests/badge.svg?branch=v4)](https://github.com/padloc/padloc/actions?workflow=Run+Tests)
 
-Simple, secure password and data management for individuals and teams (formerly known as Padlock).
+Simple, secure password and data management for individuals and teams.
+
+## About
 
 This repo is split into multiple packages:
 
-| Package Name                                   | Description                                                                                                                               |
-| ---------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| [@padloc/core](packages/core)                  | Core Logic                                                                                                                                |
-| [@padloc/app](packages/app)                    | Web-based UI components                                                                                                                   |
-| [@padloc/server](packages/server)              | The Backend Server                                                                                                                        |
-| [@padloc/pwa](packages/pwa)                    | The Web Client, a [Progressive Web App](https://developers.google.com/web/progressive-web-apps) built on top of the `@padloc/app` package |
-| [@padloc/locale](packages/locale)              | Package containing translations and other localization-related things                                                                     |
-| [@padloc/electron](packages/electron)          | The Desktop App, built with Electron                                                                                                      |
-| [@padloc/cordova](packages/cordova)            | Cordova project for building iOS and Android app.                                                                                         |
-| [@padloc/tauri (experimental)](packages/tauri) | Cross-platform native app builder for Padloc, powered by [Tauri](https://github.com/tauri-apps/tauri)                                     |
+| Package Name                            | Description                                                                                                                               |
+| --------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| [@padloc/core](packages/core)           | Core Logic                                                                                                                                |
+| [@padloc/app](packages/app)             | Web-based UI components                                                                                                                   |
+| [@padloc/server](packages/server)       | The Backend Server                                                                                                                        |
+| [@padloc/pwa](packages/pwa)             | The Web Client, a [Progressive Web App](https://developers.google.com/web/progressive-web-apps) built on top of the `@padloc/app` package |
+| [@padloc/locale](packages/locale)       | Package containing translations and other localization-related things                                                                     |
+| [@padloc/electron](packages/electron)   | The Desktop App, built with Electron                                                                                                      |
+| [@padloc/cordova](packages/cordova)     | Cordova project for building iOS and Android app.                                                                                         |
+| [@padloc/tauri](packages/tauri)         | Cross-platform native app builder for Padloc, powered by [Tauri](https://github.com/tauri-apps/tauri)                                     |
+| [@padloc/extension](packages/extension) | Padloc browser extension                                                                                                                  |
 
-## Getting Started
+## How to use
 
-#### Step 0: Install Prerequisites
-
-You'll need
-
--   [node.js](https://nodejs.org/) v12 or greater
--   [Git](https://git-scm.com/)
-
-#### Step 1: Clone the Repo
+As you can see in the [About](#about) section, there are lots of different components to play with! But at a minimum, in
+order to set up and use your own instance of Padloc you'll need to install and configure the [Server](packages/server)
+and [Web Client](packages/pwa). In practice, there a few different ways to do this, but if you just want to install and
+test Padloc locally, doing so is really quite easy:
 
 ```sh
-git clone https://github.com/padloc/padloc
+git clone git@github.com:padloc/padloc.git
 cd padloc
+npm ci
+npm start
 ```
 
-#### Step 2: Install Dependencies
+The web client is now available at `http://localhost:8080`!
 
-```sh
-npm install
-```
+In-depth guides on how to host your own "productive" version of Padloc and how to build and distribute your own versions
+of the desktop and mobile apps are coming soon!
 
-#### Step 3: Start Server and Web Client
+## Contributing
 
-```sh
-PL_DATA_DIR=~/padloc-data \
-PL_SERVER_PORT=3000 \
-PL_PWA_PORT=8080 \
-npm run start
-```
+All kinds of contributions are welcome!
 
-For more configuration options, see [Configuration](#configuration)
+If you want to **report a bug or have a feature request**, please
+[create an issue](https://github.com/padloc/padloc/issues).
 
-## Scripts
+If you **have question, feedback or would just like to chat**, head over to the
+[discussions](https://github.com/padloc/padloc/discussions) section.
 
-| Command                | Description                                                                                                                                                       |
-| ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `npm start`            | Starts both backend server and web client.                                                                                                                        |
-| `npm run server:start` | Starts only backend server.                                                                                                                                       |
-| `npm run pwa:start`    | Starts only web client (You'll need to run `npm run pwa:build` first).                                                                                            |
-| `npm run pwa:build`    | Builds the web client                                                                                                                                             |
-| `npm run dev`          | Starts backend server and client app in dev mode, which watches for changes in the source files and automatically rebuilds/restarts the corresponding components. |
-| `npm test`             | Run tests.                                                                                                                                                        |
+If you want to **contribute to Padloc directly** by implementing a new feature or fixing an existing issue, feel free to
+[create a pull request](https://github.com/padloc/padloc/pulls)! However if you plan to work on anything non-trivial,
+please do talk to us first, either by commenting on an existing issue, creating a new issue or by pinging us in the
+dissusions section!
 
-To add dependencies, you can use `scope=[scope-without-@padloc/] npm run add [package]` and to remove them, run `scope=[scope-without-@padloc/] npm run remove [package]`.
-
-Use `npm run prettier` to make "prettify" all files.
-
-## Configuration
-
-| Environment Variable | Default                          | Description                                                                                               |
-| -------------------- | -------------------------------- | --------------------------------------------------------------------------------------------------------- |
-| `PL_SERVER_PORT`     | `3000`                           | Which port to host the backend server on                                                                  |
-| `PL_SERVER_URL`      | `http://0.0.0.0:$PL_SERVER_PORT` | Public URL that will resolve to the backend server. Used by clients to send requests.                     |
-| `PL_PWA_PORT`        | `8080`                           | Which port to host the web client on                                                                      |
-| `PL_PWA_URL`         | `http://0.0.0.0:$PL_PWA_PORT`    | Public URL that will resolve to the web client. Used by the server to generate links into the web client. |
-| `PL_PWA_DIR`         | `./packages/pwa/dist`            | Build directory for web client.                                                                           |
-| `PL_DATA_DIR`        | `./data`                         | Directory used by server for persistent data storage                                                      |
-| `PL_ATTACHMENTS_DIR` | `./attachments`                  | Directory used by server to store attachments                                                             |
-| `PL_LOGS_DIR`        | `./logs`                         | Directory used by server to store logs                                                                    |
-| `PL_EMAIL_USER`      | -                                | SMTP user for sending emails.                                                                             |
-| `PL_EMAIL_SERVER`    | -                                | SMTP server for sending emails                                                                            |
-| `PL_EMAIL_PORT`      | -                                | SMTP port for sending emails                                                                              |
-| `PL_EMAIL_SECURE`    | `false`                          | SMTP use secured connection for sending emails                                                            |
-| `PL_EMAIL_PASSWORD`  | -                                | SMTP password for sending email                                                                           |
-| `PL_REPORT_ERRORS`   | -                                | Email address used for reporting unexpected errors in the backend.                                        |
+To learn how to get started working on Padloc, refer to the [Development](#development) section of the readme.
 
 ## Security
 
 For a security design overview, check out the [security whitepaper](security.md).
 
-## Deployment/Publishing
+## Development
 
-Locally, run `npm run update-version 0.0.1` replacing `0.0.1` with the version you'd like to release, and commit + push/merge.
+### Setup
 
-In GitHub Actions, run the [`Publish Release`](https://github.com/padloc/padloc/actions?workflow=Publish+Release) action to generate the release, build all targets, and attach them to the release.
+Setting up your dev environment for working with Padloc is as:
+
+```sh
+git clone git@github.com:padloc/padloc.git
+cd padloc
+npm ci
+```
+
+This may take a minute, so maybe grab a cup of ☕️.
+
+### Dev Mode
+
+To start "dev mode", simply run
+
+```sh
+npm run dev
+```
+
+from the root of the project. This will start the backend server (by default listening on port `3000`), as well as the
+PWA (available on `http://localhost:8080`) by default.
+
+The server and PWA port can be changed vie the `PL_TRANSPORT_HTTP_PORT` and `PL_PWA_PORT` environvent variables,
+respectively. For more configuration options, check out the **Conguration** section of the
+[server](packages/server#configuration) and [pwa](packages/pwa#configuration).
+
+### Formatting
+
+This project is formatted with [Prettier](https://prettier.io/). To re-format all files using our
+[.prettierrc.json](.prettierrc.json) specification, run the following from the root of the project.
+
+```sh
+npm run format
+```
+
+To simply check whether everything is formatted correctly, you can use the following command:
+
+```sh
+npm run format:check
+```
+
+### Testing
+
+To run unit tests, use:
+
+```sh
+npm run test
+```
+
+Cypress end-to-end tests can be run via:
+
+```sh
+npm run test:e2e
+```
+
+And to start cypress tests in "dev mode":
+
+```ssh
+npm run test:e2e:dev
+```
+
+### Adding / removing dependencies
+
+Since this is a monorepo consisting of multiple packages, adding/removing to/from a single package can be less than
+straightforward. The following commands are meant to make this easier.
+
+To add a dependency to a package, run:
+
+```sh
+scope=[package_name] npm run add [dependency]
+```
+
+And to remove one:
+
+```sh
+scope=[package_name] npm run remove [dependency]
+```
+
+For example, here is how you would add `typescript` to the `@padloc/server` package:
+
+```sh
+scope=server npm run add typescript
+```
+
+**Note**: We're trying to keep the number and size of third-party dependencies to a minumum, so before you add a
+dependency, please think twice if it is really needed! Pull requests with unnecessary dependencies will very likely be
+rejected.
+
+### Updating The Version
+
+The Padloc project consists of many different subpackages. To simplify versioning, we use a global version for all them.
+This means that when releasing a new version, the version of all subpackages needs to be updated, regardless of whether
+there have been changes in them or not. To update the global version accross the project, you can use the following
+command:
+
+```sh
+npm run version [semver_version]
+```
+
+### Deployment / Publishing
+
+Padloc has a lot of different components that all need to be built/released/published in different ways. To manage this
+complexitiy, we have compiled all deployment steps for all components in a single Github Workflow. To release a new
+version, simply:
+
+1. [Update project version](#updating-the-version)
+2. Commit and push.
+3. Run the [`Publish Release`](https://github.com/padloc/padloc/actions?workflow=Publish+Release) action.
+
+## Licensing
+
+This software is published under the [GNU Affero General Public License](LICENSE). If you wish to acquire a commercial
+license, please contact us as [sales@padloc.app](mailto:sales@padloc.app?subject=Padloc%20Commercial%20License).

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ For a security design overview, check out the
 
 ### Setup
 
-Setting up your dev environment for working with Padloc is as:
+Setting up your dev environment for working with Padloc is as simple as:
 
 ```sh
 git clone git@github.com:padloc/padloc.git

--- a/package.json
+++ b/package.json
@@ -58,7 +58,10 @@
         "remove": "rm packages/$scope/package-lock.json && lerna exec \"npm uninstall $1\" --scope=@padloc/$scope",
         "prettier": "prettier --write .",
         "prettier:check": "prettier --check .",
+        "format": "prettier --write .",
+        "format:check": "prettier --check .",
         "update-version": "lerna version $1 --yes",
+        "version": "lerna version $1 --yes",
         "publish": "lerna publish"
     }
 }

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
         "tauri:dev": "lerna run --parallel --scope '@padloc/{server,tauri}' --parallel dev",
         "tauri:update": "lerna run update",
         "tauri:build": "lerna run build --scope @padloc/tauri",
-        "tauri:build:production": "lerna run build:production",
+        "tauri:build:debug": "lerna run build:debug --scope @padloc/tauri",
         "repl": "cd packages/server && npm run repl && cd ../..",
         "test": "lerna run test",
         "test:e2e": "concurrently --prefix=name --prefix-length=30 --kill-others --success=first -n app,v3-app,cypress \"PL_DATA_BACKEND=memory PL_DISABLE_SW=true PL_EMAIL_BACKEND=smtp PL_EMAIL_SMTP_HOST=localhost PL_EMAIL_SMTP_PORT=1025 PL_EMAIL_SMTP_IGNORE_TLS=true npm start\" \"npm run start:v3\" \"npx maildev\" \"./node_modules/.bin/wait-on tcp:localhost:8080 && CYPRESS_CRASH_REPORTS=0 cypress run\"",

--- a/packages/electron/README.md
+++ b/packages/electron/README.md
@@ -1,0 +1,46 @@
+# @padloc/electron
+
+Padloc Desktop app, built with [Electron](https://www.electronjs.org/)
+
+## Setup
+
+The `@padloc/electron` package is meant to be used from within the
+[Padloc monorepo](../../README.md).
+
+```sh
+git clone git@github.com:padloc/padloc.git
+cd padloc
+npm ci
+cd packages/electron
+```
+
+## Building
+
+To build the app, run:
+
+```sh
+npm run build
+```
+
+The resulting build can be fund in the `dist` folder.
+
+### Build options
+
+All build options are provided as environment variables:
+
+| Variable Name   | Description                                        | Default  |
+| --------------- | -------------------------------------------------- | -------- |
+| `PL_SERVER_URL` | URL to the [server component](../server/README.md) | `./dist` |
+
+## Development
+
+For rapid development, there is also dev mode:
+
+```sh
+npm run dev
+```
+
+## Contributing
+
+For info on how to contribute to Padloc, please refer to the
+[monorepo readme](../../README.md#contributing).

--- a/packages/extension/README.md
+++ b/packages/extension/README.md
@@ -1,0 +1,55 @@
+# @padloc/extension
+
+The Padloc browser extension.
+
+## Setup
+
+The `@padloc/extension` package is meant to be used from within the
+[Padloc monorepo](../../README.md).
+
+```sh
+git clone git@github.com:padloc/padloc.git
+cd padloc
+npm ci
+cd packages/extension
+```
+
+## Building
+
+To build an unpacked version of the web extension, simply run the following from
+within the package directory.
+
+```sh
+npm run build
+```
+
+The resulting build can be fund in the `dist` folder.
+
+### Build options
+
+All build options are provided as environment variables:
+
+| Variable Name   | Description                                        | Default  |
+| --------------- | -------------------------------------------------- | -------- |
+| `PL_SERVER_URL` | URL to the [server component](../server/README.md) | `./dist` |
+
+### Installing an unpacked extension
+
+Once built, the easiest way to install and use the extension is to install it as
+an "unpacked extension". Steps vary from browser to browser:
+
+Google Chrome:
+https://developer.chrome.com/docs/extensions/mv3/getstarted/#unpacked
+
+Firefox:
+https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Your_first_WebExtension#installing
+
+## Development
+
+For development instructions, please refer to the
+[monorepo readme](../../README.md#development).
+
+## Contributing
+
+For info on how to contribute to Padloc, please refer to the
+[monorepo readme](../../README.md#contributing).

--- a/packages/locale/README.md
+++ b/packages/locale/README.md
@@ -1,13 +1,15 @@
 # Padloc Localization Package
 
-This package contains translations, word lists and various localization tools for the Padloc app.
+This package contains translations, word lists and various localization tools
+for the Padloc app.
 
 ## How To Contribute
 
 ### Translations
 
-One of the easiest ways to contribute to this project is to help create or improve translations in your
-language. Translations are stored as simple [JSON](https://www.json.org/) files in the following format:
+One of the easiest ways to contribute to this project is to help create or
+improve translations in your language. Translations are stored as simple
+[JSON](https://www.json.org/) files in the following format:
 
 ```json
 [
@@ -22,16 +24,18 @@ language. Translations are stored as simple [JSON](https://www.json.org/) files 
 ]
 ```
 
-To add or update a translation for a given text, simply locate the translation file for your language
-in the [translations directory](packages/locale/res/translations/), find the text you want to translate
-and insert your translation below. If no translation file for you language
-exists yet, you can start from scratch, using [this empty translations
-file](packages/locale/res/translations/_template.json). Simply copy it and name
-it
-`xx.json`, replacing "xx" with the appropriate lowercase [country
-code](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Officially_assigned_code_elements).
+To add or update a translation for a given text, simply locate the translation
+file for your language in the
+[translations directory](packages/locale/res/translations/), find the text you
+want to translate and insert your translation below. If no translation file for
+you language exists yet, you can start from scratch, using
+[this empty translations file](packages/locale/res/translations/_template.json).
+Simply copy it and name it `xx.json`, replacing "xx" with the appropriate
+lowercase
+[country code](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Officially_assigned_code_elements).
 
 ### Word Lists
 
-Word lists are used to generate random passphrases from a list of commonly used words from a given language.
-You can find all existing word lists [here](packages/locale/res/wordlists/).
+Word lists are used to generate random passphrases from a list of commonly used
+words from a given language. You can find all existing word lists
+[here](packages/locale/res/wordlists/).

--- a/packages/pwa/README.md
+++ b/packages/pwa/README.md
@@ -1,0 +1,67 @@
+# @padloc/pwa
+
+The Padloc Web Client, a
+[Progressive Web App](https://developers.google.com/web/progressive-web-apps).
+
+## Setup
+
+Currently the `@padloc/pwa` package is meant to be used from within the
+[Padloc monorepo](../../README.md). A standalone npm package is coming soon!
+
+```sh
+git clone git@github.com:padloc/padloc.git
+cd padloc
+npm ci
+cd packages/pwa
+```
+
+## Building
+
+To build the pwa, simply run the following from within the package directory.
+
+```sh
+npm run build
+```
+
+### Build options
+
+All build options are provided as environment variables:
+
+| Variable Name   | Description                                        | Default  |
+| --------------- | -------------------------------------------------- | -------- |
+| `PL_SERVER_URL` | URL to the [server component](../server/README.md) | `./dist` |
+| `PL_PWA_DIR`    | Build output directory                             | `./dist` |
+| `PL_DISABLE_SW` | Disable web worker                                 | `./dist` |
+
+## Web Server
+
+This package also has a bundled web server, which can be used to serve the web
+app:
+
+```sh
+npm run start
+```
+
+By default the app ist hosted on port `3000`. To change the port, you can use
+the `PL_PWA_PORT` environment variable:
+
+```sh
+PL_PWA_PORT=8081 npm run start
+```
+
+Note that this requires the PWA to be [built](#building) first. To build and
+serve the app in one step, run:
+
+```sh
+npm run build_and_start
+```
+
+## Development
+
+For development instructions, please refer to the
+[monorepo readme](../../README.md#development).
+
+## Contributing
+
+For info on how to contribute to Padloc, please refer to the
+[monorepo readme](../../README.md#contributing).

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -116,6 +116,10 @@ a [`sample .env file`](resources/example.env). Simply copy the file to wherever
 you want to keep it and the uncomment and edit any options you want to set (more
 info about the most important configuration options below).
 
+### General Server Options
+
+TBD
+
 ### Data Transport
 
 TBD
@@ -140,9 +144,15 @@ TBD
 
 TBD
 
-### General Server Options
+## Development
 
-TBD
+For development instructions, please refer to the
+[monorepo readme](../../README.md#development).
+
+## Contributing
+
+For info on how to contribute to Padloc, please refer to the
+[monorepo readme](../../README.md#contributing).
 
 ## Licensing
 

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -4,8 +4,8 @@ This package contains the Padloc backend server component.
 
 ## How to use
 
-Currently the `@padloc/server` package is meant to run from within a copy of the [Padloc monorepo](../../README.md). A
-standalone npm package is coming soon!
+Currently the `@padloc/server` package is meant to be run from within the
+[Padloc monorepo](../../README.md). A standalone npm package is coming soon!
 
 First, clone and install the monorepo:
 
@@ -28,45 +28,54 @@ cd packages/server
 npm start
 ```
 
-By default, the server will listen on port `3000`. To can set a different port via the `PL_TRANSPORT_HTTP_PORT`
-environment variable:
+By default, the server will listen on port `3000`. To can set a different port
+via the `PL_TRANSPORT_HTTP_PORT` environment variable:
 
 ```sh
 PL_TRANSPORT_HTTP_PORT=3001 npm start
 ```
 
-For more configuration options, please consult the [Configuration](#configuration) section of this readme.
+For more configuration options, please consult the
+[Configuration](#configuration) section of this readme.
 
 ## Configuration
 
-Padloc comes with a lot of configuration options, most of which deal with selecting and configuring backends for certain
-aspects of the software.
+Padloc comes with a lot of configuration options, most of which deal with
+selecting and configuring backends for certain aspects of the software.
 
-All configuration options for the `@padloc/server` package are defined in the [src/config](src/config.ts) moule, and
-while we'll be discussing the most important ones here, looking at the source can be a great way to understand how
-configuration options are structured and parsed, and to familiarise yourself with some of the more advanced
-configuration options.
+All configuration options for the `@padloc/server` package are defined in the
+[src/config](src/config.ts) moule, and while we'll be discussing the most
+important ones here, looking at the source can be a great way to understand how
+configuration options are structured and parsed, and to familiarise yourself
+with some of the more advanced configuration options.
 
-Most of Padloc's configuration happens through environment variables, and because there are a lot of options and
-therefore a lot of different variables, we've come up with a simple naming scheme that's based on the hierarchical
-nature of Padloc's configuration. This means that most of the time, you'll be able to guess the environment variable
-name simply by looking at the structure defined in [src/config](src/config.ts).
+Most of Padloc's configuration happens through environment variables, and
+because there are a lot of options and therefore a lot of different variables,
+we've come up with a simple naming scheme that's based on the hierarchical
+nature of Padloc's configuration. This means that most of the time, you'll be
+able to guess the environment variable name simply by looking at the structure
+defined in [src/config](src/config.ts).
 
-The generall pattern is that in order to configure a certain aspect, you'll first choose which backend you want to use.
-Then, you'll provide the configuration options required by that specific backend by setting the corresponding
-environment variables, which are name-spaced with the backend's name.
+The generall pattern is that in order to configure a certain aspect, you'll
+first choose which backend you want to use. Then, you'll provide the
+configuration options required by that specific backend by setting the
+corresponding environment variables, which are name-spaced with the backend's
+name.
 
-For example, you can choose which backend to use for data storage by setting the `PL_DATA_BACKEND` variable. By default,
-Padloc uses LevelDB for data storage on the server side. To use PostgresSQL instead, simply set the `PL_DATA_BACKEND`
+For example, you can choose which backend to use for data storage by setting the
+`PL_DATA_BACKEND` variable. By default, Padloc uses LevelDB for data storage on
+the server side. To use PostgreSQL instead, simply set the `PL_DATA_BACKEND`
 variable to `postgres`.
 
 ```sh
 PL_DATA_BACKEND=postgres
 ```
 
-Naturally, Padloc now needs to know where to reach the Postgres server, so you'll need to set the corresponding
-environment variables. Our naming scheme dictates that all postgres-related configuration options are prefixed with
-`PL_DATA_POSTGRES_*`. An exampe for a full postgres configuration might look as follows:
+Naturally, Padloc now needs to know where to reach the Postgres server, so
+you'll need to set the corresponding environment variables. Our naming scheme
+dictates that all postgres-related configuration options are prefixed with
+`PL_DATA_POSTGRES_*`. An exampe for a full postgres configuration might look as
+follows:
 
 ```sh
 PL_DATA_BACKEND=postgres
@@ -77,30 +86,35 @@ PL_DATA_POSTGRES_PASSWORD=somepassword
 PL_DATA_POSTGRES_DATABASE=padloc
 ```
 
-Padloc is designed to be extremely modular, so you'll find that most aspects of the software can be configured to use
-different backends. And if your technology of choice isn't supported, it's usually fairly straightforward to implement
-the required backend. [Pull requests welcome](../../README.md#contributing)!
+Padloc is designed to be extremely modular, so you'll find that most aspects of
+the software can be configured to use different backends. And if your technology
+of choice isn't supported, it's usually fairly straightforward to implement the
+required backend. [Pull requests welcome](../../README.md#contributing)!
 
 ### Setting Environment Variables
 
-Environment variables can be set either the traditional way (consult the documentation of your operating system) or via
-a [`.env`](https://www.npmjs.com/package/dotenv) file. By default, Padloc will look for a file named `.env` in the
-current working directory, but you can also specifiy the path to a different file using the `--env` flag:
+Environment variables can be set either the traditional way (consult the
+documentation of your operating system) or via a
+[`.env`](https://www.npmjs.com/package/dotenv) file. By default, Padloc will
+look for a file named `.env` in the current working directory, but you can also
+specifiy the path to a different file using the `--env` flag:
 
 ```sh
 npm start -- --env=/path/to/env/file/.env
 ```
 
-Note that by default, environment variables set through other means take preference over the ones defined in your `.env`
-file. If you want your `.env` file to override any variables set elsewhere, use the `--env-override` flag:
+Note that by default, environment variables set through other means take
+preference over the ones defined in your `.env` file. If you want your `.env`
+file to override any variables set elsewhere, use the `--env-override` flag:
 
 ```sh
 npm start -- --env=/path/to/env/file/.env --env-override
 ```
 
-For your convenience, we've compiled **all** available environment variables in a
-[`sample .env file`](resources/example.env). Simply copy the file to wherever you want to keep it and the uncomment and
-edit any options you want to set (more info about the most important configuration options below).
+For your convenience, we've compiled **all** available environment variables in
+a [`sample .env file`](resources/example.env). Simply copy the file to wherever
+you want to keep it and the uncomment and edit any options you want to set (more
+info about the most important configuration options below).
 
 ### Data Transport
 
@@ -132,6 +146,7 @@ TBD
 
 ## Licensing
 
-This software is published under the [GNU Affero General Public License](../../LICENSE). If you wish to acquire a
+This software is published under the
+[GNU Affero General Public License](../../LICENSE). If you wish to acquire a
 commercial license, please contact us as
 [sales@padloc.app](mailto:sales@padloc.app?subject=Padloc%20Commercial%20License).

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -1,0 +1,137 @@
+# @padloc/server
+
+This package contains the Padloc backend server component.
+
+## How to use
+
+Currently the `@padloc/server` package is meant to run from within a copy of the [Padloc monorepo](../../README.md). A
+standalone npm package is coming soon!
+
+First, clone and install the monorepo:
+
+```sh
+git clone git@github.com:padloc/padloc.git
+cd padloc
+npm ci
+```
+
+Then, you can either start the server from the root of the project...
+
+```sh
+npm run server:start
+```
+
+Or from the package directory.
+
+```sh
+cd packages/server
+npm start
+```
+
+By default, the server will listen on port `3000`. To can set a different port via the `PL_TRANSPORT_HTTP_PORT`
+environment variable:
+
+```sh
+PL_TRANSPORT_HTTP_PORT=3001 npm start
+```
+
+For more configuration options, please consult the [Configuration](#configuration) section of this readme.
+
+## Configuration
+
+Padloc comes with a lot of configuration options, most of which deal with selecting and configuring backends for certain
+aspects of the software.
+
+All configuration options for the `@padloc/server` package are defined in the [src/config](src/config.ts) moule, and
+while we'll be discussing the most important ones here, looking at the source can be a great way to understand how
+configuration options are structured and parsed, and to familiarise yourself with some of the more advanced
+configuration options.
+
+Most of Padloc's configuration happens through environment variables, and because there are a lot of options and
+therefore a lot of different variables, we've come up with a simple naming scheme that's based on the hierarchical
+nature of Padloc's configuration. This means that most of the time, you'll be able to guess the environment variable
+name simply by looking at the structure defined in [src/config](src/config.ts).
+
+The generall pattern is that in order to configure a certain aspect, you'll first choose which backend you want to use.
+Then, you'll provide the configuration options required by that specific backend by setting the corresponding
+environment variables, which are name-spaced with the backend's name.
+
+For example, you can choose which backend to use for data storage by setting the `PL_DATA_BACKEND` variable. By default,
+Padloc uses LevelDB for data storage on the server side. To use PostgresSQL instead, simply set the `PL_DATA_BACKEND`
+variable to `postgres`.
+
+```sh
+PL_DATA_BACKEND=postgres
+```
+
+Naturally, Padloc now needs to know where to reach the Postgres server, so you'll need to set the corresponding
+environment variables. Our naming scheme dictates that all postgres-related configuration options are prefixed with
+`PL_DATA_POSTGRES_*`. An exampe for a full postgres configuration might look as follows:
+
+```sh
+PL_DATA_BACKEND=postgres
+PL_DATA_POSTGRES_HOST=localhost
+PL_DATA_POSTGRES_PORT=5432
+PL_DATA_POSTGRES_USER=someuser
+PL_DATA_POSTGRES_PASSWORD=somepassword
+PL_DATA_POSTGRES_DATABASE=padloc
+```
+
+Padloc is designed to be extremely modular, so you'll find that most aspects of the software can be configured to use
+different backends. And if your technology of choice isn't supported, it's usually fairly straightforward to implement
+the required backend. [Pull requests welcome](../../README.md#contributing)!
+
+### Setting Environment Variables
+
+Environment variables can be set either the traditional way (consult the documentation of your operating system) or via
+a [`.env`](https://www.npmjs.com/package/dotenv) file. By default, Padloc will look for a file named `.env` in the
+current working directory, but you can also specifiy the path to a different file using the `--env` flag:
+
+```sh
+npm start -- --env=/path/to/env/file/.env
+```
+
+Note that by default, environment variables set through other means take preference over the ones defined in your `.env`
+file. If you want your `.env` file to override any variables set elsewhere, use the `--env-override` flag:
+
+```sh
+npm start -- --env=/path/to/env/file/.env --env-override
+```
+
+For your convenience, we've compiled **all** available environment variables in a
+[`sample .env file`](resources/example.env). Simply copy the file to wherever you want to keep it and the uncomment and
+edit any options you want to set (more info about the most important configuration options below).
+
+### Data Transport
+
+TBD
+
+### Data Storage
+
+TBD
+
+### Attachment Storage
+
+TBD
+
+### Logging
+
+TBD
+
+### Authentication
+
+TBD
+
+### Provisioning
+
+TBD
+
+### General Server Options
+
+TBD
+
+## Licensing
+
+This software is published under the [GNU Affero General Public License](../../LICENSE). If you wish to acquire a
+commercial license, please contact us as
+[sales@padloc.app](mailto:sales@padloc.app?subject=Padloc%20Commercial%20License).

--- a/packages/server/package-lock.json
+++ b/packages/server/package-lock.json
@@ -20,6 +20,7 @@
 				"@types/stripe": "8.0.416",
 				"ansi-colors": "4.1.1",
 				"date-fns": "2.22.1",
+				"dotenv": "16.0.0",
 				"fs-extra": "10.0.0",
 				"geolite2-redist": "2.0.4",
 				"level": "7.0.0",
@@ -1887,6 +1888,14 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.3.1"
+			}
+		},
+		"node_modules/dotenv": {
+			"version": "16.0.0",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.0.tgz",
+			"integrity": "sha512-qD9WU0MPM4SWLPJy/r2Be+2WgQj8plChsyrCNQzW/0WjvcJQiKQJ9mH3ZgB3fxbUUxgc/11ZJ0Fi5KiimWGz2Q==",
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"node_modules/dynamic-dedupe": {
@@ -5697,6 +5706,11 @@
 			"resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
 			"integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
 			"dev": true
+		},
+		"dotenv": {
+			"version": "16.0.0",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.0.tgz",
+			"integrity": "sha512-qD9WU0MPM4SWLPJy/r2Be+2WgQj8plChsyrCNQzW/0WjvcJQiKQJ9mH3ZgB3fxbUUxgc/11ZJ0Fi5KiimWGz2Q=="
 		},
 		"dynamic-dedupe": {
 			"version": "0.3.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -31,6 +31,7 @@
         "@types/stripe": "8.0.416",
         "ansi-colors": "4.1.1",
         "date-fns": "2.22.1",
+        "dotenv": "16.0.0",
         "fs-extra": "10.0.0",
         "geolite2-redist": "2.0.4",
         "level": "7.0.0",

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -14,6 +14,8 @@ import { StripeProvisionerConfig } from "./provisioning/stripe";
 import { MixpanelConfig } from "./logging/mixpanel";
 import { HTTPReceiverConfig } from "./transport/http";
 import { PostgresConfig } from "./storage/postgres";
+import dotenv from "dotenv";
+import { resolve } from "path";
 
 export class TransportConfig extends Config {
     @ConfigParam()
@@ -34,9 +36,6 @@ export class EmailConfig extends Config {
 
     @ConfigParam(SMTPConfig)
     smtp?: SMTPConfig;
-
-    @ConfigParam("string")
-    footer?: string;
 }
 
 export class DataStorageConfig extends Config {
@@ -153,5 +152,9 @@ export class PadlocConfig extends Config {
 }
 
 export function getConfig() {
+    const envFile = process.argv.find((arg) => arg.startsWith("--env="))?.slice(6);
+    const path = envFile && resolve(process.cwd(), envFile);
+    const override = process.argv.includes("--env-override");
+    dotenv.config({ override, path });
     return new PadlocConfig().fromEnv(process.env as { [v: string]: string }, "PL_");
 }

--- a/packages/server/src/email/smtp.ts
+++ b/packages/server/src/email/smtp.ts
@@ -12,10 +12,10 @@ export class SMTPConfig extends Config {
     }
 
     @ConfigParam()
-    host: string = "";
+    host: string = "localhost";
 
-    @ConfigParam()
-    port: string = "";
+    @ConfigParam("number")
+    port: number = 1025;
 
     @ConfigParam("boolean")
     secure: boolean = false;

--- a/packages/server/src/storage/mongodb.ts
+++ b/packages/server/src/storage/mongodb.ts
@@ -7,7 +7,7 @@ import { Config, ConfigParam } from "@padloc/core/src/config";
 export class MongoDBStorageConfig extends Config {
     @ConfigParam()
     host: string = "localhost";
-    @ConfigParam()
+    @ConfigParam("number")
     port: number = 27017;
     @ConfigParam()
     username: string = "";

--- a/packages/tauri/README.md
+++ b/packages/tauri/README.md
@@ -1,14 +1,17 @@
 # @padloc/tauri (experimental)
 
-Cross-platform native app builder for Padloc, powered by [Tauri](https://github.com/tauri-apps/tauri).
+Cross-platform native app builder for Padloc, powered by
+[Tauri](https://github.com/tauri-apps/tauri).
 
 ## How To Use
 
-1. Follow the steps described in the [Getting
-   Started](https://github.com/padloc/padloc/blob/master/README.md#getting-started)
+1. Follow the steps described in the
+   [Getting Started](https://github.com/padloc/padloc/blob/master/README.md#getting-started)
    section of repo readme.
 
-2. Follow Tauri's [setup guide](https://tauri.studio/docs/getting-started/intro/#setting-up-your-environment) for your platform.
+2. Follow Tauri's
+   [setup guide](https://tauri.studio/docs/getting-started/intro/#setting-up-your-environment)
+   for your platform.
 
 3. Build the app:
 
@@ -17,8 +20,8 @@ Cross-platform native app builder for Padloc, powered by [Tauri](https://github.
     npm run build
     ```
 
-    Don't forget to set the server url [configuration
-    variable](https://github.com/padloc/padloc/blob/master/README.md#configuration).
+    Don't forget to set the server url
+    [configuration variable](https://github.com/padloc/padloc/blob/master/README.md#configuration).
     For example, if you want the app to connect to the official Padloc server:
 
     ```sh
@@ -29,12 +32,21 @@ Cross-platform native app builder for Padloc, powered by [Tauri](https://github.
 
 Initial tests look very promising. Some things that still need figuring out.
 
--   [ ] **Persistent Storage**: Using IndexedDB doesn't work here for various reasons. Best option is
-        probably writing a simple storage backend using Tauri's [file system api](https://tauri.studio/docs/api/js#file-system).
--   [ ] **Copy & Paste**: Doesn't work out of the box. Figure out steps to make it work.
--   [ ] **Auto-updating**: Must-have feature for desktop apps at least those not distributed through app stores or package managers. Not available in Tauri yet, but apparently on the roadmap.
+-   [ ] **Persistent Storage**: Using IndexedDB doesn't work here for various
+        reasons. Best option is probably writing a simple storage backend using
+        Tauri's [file system api](https://tauri.studio/docs/api/js#file-system).
+-   [ ] **Copy & Paste**: Doesn't work out of the box. Figure out steps to make
+        it work.
+-   [ ] **Auto-updating**: Must-have feature for desktop apps at least those not
+        distributed through app stores or package managers. Not available in
+        Tauri yet, but apparently on the roadmap.
 -   [ ] **Code-signing**: Also on Tauri's roadmap, but not available yet
--   [ ] **Run without the embedded web server**: Would be the safer choice security-wise but doesn't seem to work as-is. Need to figure out what changes are needed to make it work.
--   [ ] **Mobile**: Waiting for Tauri to support Android and iOS builds, which could potentially replace Cordova.
--   [ ] **Biometric Authentication**: This is a must-have on mobile but it would be nice to have it on desktop as well
--   [ ] **Secure Enclave / Key Store**: Along with biometric authentication, this is a requirement for biometric unlock.
+-   [ ] **Run without the embedded web server**: Would be the safer choice
+        security-wise but doesn't seem to work as-is. Need to figure out what
+        changes are needed to make it work.
+-   [ ] **Mobile**: Waiting for Tauri to support Android and iOS builds, which
+        could potentially replace Cordova.
+-   [ ] **Biometric Authentication**: This is a must-have on mobile but it would
+        be nice to have it on desktop as well
+-   [ ] **Secure Enclave / Key Store**: Along with biometric authentication,
+        this is a requirement for biometric unlock.

--- a/packages/tauri/README.md
+++ b/packages/tauri/README.md
@@ -1,52 +1,56 @@
-# @padloc/tauri (experimental)
+# @padloc/tauri
 
-Cross-platform native app builder for Padloc, powered by
+Native cross-platform app, powered by
 [Tauri](https://github.com/tauri-apps/tauri).
 
-## How To Use
+## Setup
 
-1. Follow the steps described in the
-   [Getting Started](https://github.com/padloc/padloc/blob/master/README.md#getting-started)
-   section of repo readme.
+The `@padloc/tauri` package is meant to be used from within the
+[Padloc monorepo](../../README.md).
 
-2. Follow Tauri's
-   [setup guide](https://tauri.studio/docs/getting-started/intro/#setting-up-your-environment)
-   for your platform.
+```sh
+git clone git@github.com:padloc/padloc.git
+cd padloc
+npm ci
+cd packages/tauri
+```
 
-3. Build the app:
+You also need to follow
+[Tauri's setup guide](https://tauri.studio/docs/getting-started/intro/#setting-up-your-environment)
 
-    ```sh
-    cd packages/tauri
-    npm run build
-    ```
+## Building
 
-    Don't forget to set the server url
-    [configuration variable](https://github.com/padloc/padloc/blob/master/README.md#configuration).
-    For example, if you want the app to connect to the official Padloc server:
+To build the app, run:
 
-    ```sh
-    PL_SERVER_URL=https://api.padloc.app npm run build
-    ```
+```sh
+npm run build
+```
 
-## TODOs
+The resulting build can be fund in the `dist` folder.
 
-Initial tests look very promising. Some things that still need figuring out.
+You can also build a debug version of the app, useful for - well - debugging:
 
--   [ ] **Persistent Storage**: Using IndexedDB doesn't work here for various
-        reasons. Best option is probably writing a simple storage backend using
-        Tauri's [file system api](https://tauri.studio/docs/api/js#file-system).
--   [ ] **Copy & Paste**: Doesn't work out of the box. Figure out steps to make
-        it work.
--   [ ] **Auto-updating**: Must-have feature for desktop apps at least those not
-        distributed through app stores or package managers. Not available in
-        Tauri yet, but apparently on the roadmap.
--   [ ] **Code-signing**: Also on Tauri's roadmap, but not available yet
--   [ ] **Run without the embedded web server**: Would be the safer choice
-        security-wise but doesn't seem to work as-is. Need to figure out what
-        changes are needed to make it work.
--   [ ] **Mobile**: Waiting for Tauri to support Android and iOS builds, which
-        could potentially replace Cordova.
--   [ ] **Biometric Authentication**: This is a must-have on mobile but it would
-        be nice to have it on desktop as well
--   [ ] **Secure Enclave / Key Store**: Along with biometric authentication,
-        this is a requirement for biometric unlock.
+```sh
+npm run build:debug
+```
+
+### Build options
+
+All build options are provided as environment variables:
+
+| Variable Name   | Description                                        | Default  |
+| --------------- | -------------------------------------------------- | -------- |
+| `PL_SERVER_URL` | URL to the [server component](../server/README.md) | `./dist` |
+
+## Development
+
+For rapid development, there is also dev mode:
+
+```sh
+npm run dev
+```
+
+## Contributing
+
+For info on how to contribute to Padloc, please refer to the
+[monorepo readme](../../README.md#contributing).

--- a/security.md
+++ b/security.md
@@ -17,26 +17,26 @@ the technical knowledge to do so, which brings us to...
 
 ### Transparency
 
-It is a widely know fact among security experts that [Security through
-Obscurity](https://en.wikipedia.org/wiki/security_through_obscurity) is not
-only ineffective, but can in fact be harmful if used to cover up otherwise
-sloppy security practices. We believe that full transparency is not only the
-best foundation for trust, but also allows us and other independent reviewers
-to discover and fix any potential security flaws and efficiently as quickly as
-possible.
+It is a widely know fact among security experts that
+[Security through Obscurity](https://en.wikipedia.org/wiki/security_through_obscurity)
+is not only ineffective, but can in fact be harmful if used to cover up
+otherwise sloppy security practices. We believe that full transparency is not
+only the best foundation for trust, but also allows us and other independent
+reviewers to discover and fix any potential security flaws and efficiently as
+quickly as possible.
 
 ### No Trust Required
 
 While Padlocs open source nature is helpful in uncovering unintended
-vulnerabilities in the source code, it is, by itself, insufficient for
-verifying that the code actually deployed in production is not altered in a way
-that may compromise the security of the application either intentionally or
+vulnerabilities in the source code, it is, by itself, insufficient for verifying
+that the code actually deployed in production is not altered in a way that may
+compromise the security of the application either intentionally or
 unintentionally. This is why we take additional steps to make sure that some
-parts of the architecture can in fact be verified in production, while others
-do not need to be verified by design (see [Possible Attack-Vectors And
-Mitigations](#possible-attach-vectors-and-mitigations)). This means that unlike
-other products, Padloc does not require explicit trust between the end user
-and the host.
+parts of the architecture can in fact be verified in production, while others do
+not need to be verified by design (see
+[Possible Attack-Vectors And Mitigations](#possible-attach-vectors-and-mitigations)).
+This means that unlike other products, Padloc does not require explicit trust
+between the end user and the host.
 
 ## Encryption
 
@@ -46,18 +46,19 @@ Padloc utilizes three basic encryption schemes.
 ### Simple Symmetric Encryption
 
 This is the most basic encryption scheme used in Padloc. Simple encryption
-employs a symmetric cipher to encrypt the provided data with
-a randomly generated key. The encrypted data, along with the encryption
-parameters needed for decryption, is stored in a container object, which
-can then be stored or transmitted securely. Padloc currently uses the AES
-cipher in GCM mode, but other options may be added in the future.
+employs a symmetric cipher to encrypt the provided data with a randomly
+generated key. The encrypted data, along with the encryption parameters needed
+for decryption, is stored in a container object, which can then be stored or
+transmitted securely. Padloc currently uses the AES cipher in GCM mode, but
+other options may be added in the future.
 
 #### Encryption
 
 1. Choose a random encryption key `k`
 2. Choose a random initialization vector `iv` and additional data `a` (for
    authenticated encryption modes)
-3. Generate the encrypted data `c = AES_encrypt(k, p, iv, a)` from the plain text `p`
+3. Generate the encrypted data `c = AES_encrypt(k, p, iv, a)` from the plain
+   text `p`
 4. Store `c`, `iv` and `a` in the container `C`
 
 ```
@@ -82,9 +83,9 @@ cipher in GCM mode, but other options may be added in the future.
 
 ### Password-Based Encryption
 
-In the password-based encryption scheme (based on the [PBES2
-standard](https://tools.ietf.org/html/rfc2898#section-6.2)) an encryption key
-is derived from a user password using the
+In the password-based encryption scheme (based on the
+[PBES2 standard](https://tools.ietf.org/html/rfc2898#section-6.2)) an encryption
+key is derived from a user password using the
 [PBKDF2](https://en.wikipedia.org/wiki/PBKDF2) key derivation function.
 
 #### Encryption
@@ -94,7 +95,8 @@ is derived from a user password using the
 3. Generate `k = PBDKF2(p, s, i)`
 4. Choose a random initialization vector `iv` and additional data `a` (for
    authenticated encryption modes)
-5. Generate the encrypted data `c = AES_encrypt(k, p, iv, a)` from the plain text `p`
+5. Generate the encrypted data `c = AES_encrypt(k, p, iv, a)` from the plain
+   text `p`
 6. Store `s`, `i`, `c`, `iv` and `a` in the container `C`
 
 ```
@@ -128,25 +130,28 @@ is derived from a user password using the
 
 ### Shared-Key Encryption
 
-Shared-key encryption is used to securely share sensitive data between
-a number of independent accessors without the need for them to share a
-common password. This encryption scheme is loosely based on the [JSON Web
-Encryption](https://tools.ietf.org/html/rfc7516) specification where a shared
-symmetric encryption key is individually encrypted with each accessors public
-key and stored alongside the encrypted data. Accessors can then access the data
-by using their private key to decrypt the AES encryption key which is in turn
-used to decrypt the original data.
+Shared-key encryption is used to securely share sensitive data between a number
+of independent accessors without the need for them to share a common password.
+This encryption scheme is loosely based on the
+[JSON Web Encryption](https://tools.ietf.org/html/rfc7516) specification where a
+shared symmetric encryption key is individually encrypted with each accessors
+public key and stored alongside the encrypted data. Accessors can then access
+the data by using their private key to decrypt the AES encryption key which is
+in turn used to decrypt the original data.
 
 #### Encryption
 
 1. Generate a random encryption key `k`
 2. Choose a random initialization vector `iv` and additional data `a` (for
    authenticated encryption modes)
-3. Generate the encrypted data `c = AES_encrypt(k, p, iv, a)` from the plain text `p`
-4. Let `[A_1, A_2, ..., A_n], A_n = { id_n, pub_n }` be a number of desired accessors
-   where `pub_n` is the accessors public key and `id_n` a unique identifier.
+3. Generate the encrypted data `c = AES_encrypt(k, p, iv, a)` from the plain
+   text `p`
+4. Let `[A_1, A_2, ..., A_n], A_n = { id_n, pub_n }` be a number of desired
+   accessors where `pub_n` is the accessors public key and `id_n` a unique
+   identifier.
 5. For each accessor, generate `K_n = RSA_encrypt(pub_n, k)`
-6. Store `c`, `iv`, `a`, and `K = [{ id_1, K_1}, ..., {id_n, K_n}]` in container `C`
+6. Store `c`, `iv`, `a`, and `K = [{ id_1, K_1}, ..., {id_n, K_n}]` in container
+   `C`
 
 ```
 ┏━━━━━━━━━━━━━━┓                ┌───────────────────────────────────────────────────────────┐
@@ -216,22 +221,22 @@ The **Account** object represents an individual Padloc user and is central to
 Padlocs encryption and authentication mechanisms. Each **Account** holds the
 following information:
 
--   The user's **email address** is not only used as a communication channel but,
-    more importantly, serves as a unique, human-verifiable identifier for each
-    Padloc user.
+-   The user's **email address** is not only used as a communication channel
+    but, more importantly, serves as a unique, human-verifiable identifier for
+    each Padloc user.
 -   A RSA **private key** and **public key** pair is used in places where a user
-    needs to be granted access to data protected via the [Shared-Key Encryption
-    Scheme](#shared-key-encryption).
+    needs to be granted access to data protected via the
+    [Shared-Key Encryption Scheme](#shared-key-encryption).
 -   A HMAC key used for signing and verifing organization details (see
     [Organizations And Shared Vaults / Adding Members](#adding-members)
 -   A unique, immutable id
 -   A (display) name
 
 The Accounts **private key** and **organization signing key** are considered
-secret and should only ever be accessible to the Account owner themselves.
-They are therefore encrypted at rest using the [Password-Based Encryption
-Scheme](#password-based-encryption) with the users [**Master Password**](#the-master-password)
-serving as the secret passphrase.
+secret and should only ever be accessible to the Account owner themselves. They
+are therefore encrypted at rest using the
+[Password-Based Encryption Scheme](#password-based-encryption) with the users
+[**Master Password**](#the-master-password) serving as the secret passphrase.
 
 ```
                                  ┏━━━━━━━━━━━━━━━━━━━━━┓
@@ -258,13 +263,13 @@ serving as the secret passphrase.
 
 A password managers core functionality is the secure storage of sensitive data
 like passwords, credit card details and or any other kind or data a user may
-want to protect from prying eyes. In Padloc, this data is stored within so-called
-**Vaults**.
+want to protect from prying eyes. In Padloc, this data is stored within
+so-called **Vaults**.
 
-A Vault is basically a container object that employs the [Shared-Key
-Encryption Scheme](#shared-key-encryption) to encrypt and store sensitive data
-in a way that makes it accessible to only a number of specific users, represented
-by their corresponding **Account** objects.
+A Vault is basically a container object that employs the
+[Shared-Key Encryption Scheme](#shared-key-encryption) to encrypt and store
+sensitive data in a way that makes it accessible to only a number of specific
+users, represented by their corresponding **Account** objects.
 
 ```
 ┏━━━━━━━━━━━━━━━┓                 ┏━━━━━━━━━━━━━━┓
@@ -294,9 +299,9 @@ verification.
 ### Vault Access Management
 
 The previous sections describe how Vault data can be shared securely between
-multiple known accounts. An additional challenge lies in deciding who shall
-have access to a given vault as well as obtaining and verifying each accessors
-public key before encryption.
+multiple known accounts. An additional challenge lies in deciding who shall have
+access to a given vault as well as obtaining and verifying each accessors public
+key before encryption.
 
 The organisation structure depicted below determines which member shall have
 access to a given vault. Members can either be assigned to a **Vault** directly
@@ -324,13 +329,14 @@ or indirectly via a **Group**.
                         └──────────────┘
 ```
 
-Every time a **Vault** participant encrypts the vault data, they perform
-the following steps:
+Every time a **Vault** participant encrypts the vault data, they perform the
+following steps:
 
 1. Determine accessors based on organization structure.
-2. Verify each accessor's identity and public key (see [Verifying
-   Members](#verifying-members))
-3. Encrypt the data using the steps outlined in [Shared-Key Encryption](#shared-key-encryption)
+2. Verify each accessor's identity and public key (see
+   [Verifying Members](#verifying-members))
+3. Encrypt the data using the steps outlined in
+   [Shared-Key Encryption](#shared-key-encryption)
 
 Each participating member can now access the Vault data using their own private
 key.
@@ -345,17 +351,17 @@ information:
 -   The organization **name** is chosen by the organization owner and is mainly
     used for display purposes
 -   A RSA **public key** and **private key** pair that is used to sign and
-    verify public keys and identifying information of its members. See [Signing
-    Member Information](#adding-members) and [Verifying
-    Members](#verifying-members) for details.
+    verify public keys and identifying information of its members. See
+    [Signing Member Information](#adding-members) and
+    [Verifying Members](#verifying-members) for details.
 -   An AES key (in the following called "**invites key**") used to encrypt the
-    invite verification code during [key
-    exchange](#trustless-server-mediated-key-exchange)
+    invite verification code during
+    [key exchange](#trustless-server-mediated-key-exchange)
 
-The organization's **private key** and **invites key** are considered secret
-and need therefore be encrypted at rest. For this, the organization acts as a
-[Shared Crypto Container](#shared-key-encryption) with the [organization
-owners](#owner) acting as accessors.
+The organization's **private key** and **invites key** are considered secret and
+need therefore be encrypted at rest. For this, the organization acts as a
+[Shared Crypto Container](#shared-key-encryption) with the
+[organization owners](#owner) acting as accessors.
 
 ```
 ┏━━━━━━━━━━━━━━━┓                ┏━━━━━━━━━━━━━━━━━━━━┓
@@ -378,18 +384,19 @@ As with all cryptographic schemes that involve public-key encryption, a major
 challenge when dealing with shared vaults is securely exchanging and verifying
 the public keys and associated identities of all involved parties. This
 undertaking is complicated further by the fact that, although all communication
-and data transfer is generally mediated by a central server, Padlocs [Zero-Trust
-Principle](#no-trust-required) requires that this server (or any party
-potentially listening in on the connection) is never in the position to
+and data transfer is generally mediated by a central server, Padlocs
+[Zero-Trust Principle](#no-trust-required) requires that this server (or any
+party potentially listening in on the connection) is never in the position to
 directly access any sensitive data or trick a participant into granting them
 access either directly or indirectly.
 
 Instead of exchanging keys between all organization members directly, Padloc
 uses a simple verification chain where the public keys and identfying
-information of all members are signed and verified with a dedicated RSA key
-pair owned by the organization (see [Metadata and Cryptographic
-Keys](#metadata-and-cryptographic-keys)). The corresponding public key must in
-turn be signed and verified by each member using their individual, dedicated HMAC key.
+information of all members are signed and verified with a dedicated RSA key pair
+owned by the organization (see
+[Metadata and Cryptographic Keys](#metadata-and-cryptographic-keys)). The
+corresponding public key must in turn be signed and verified by each member
+using their individual, dedicated HMAC key.
 
 #### Trustless Server-Mediated Key Exchange
 
@@ -397,22 +404,28 @@ Before a new member can be added to an Organization, a key exchange has to take
 place between the organization (represented by the organization owner) and the
 new member. The key exchange is performed as follows:
 
-1. The **organization owner `O`** chooses a **random passphrase `p`**, a **random salt `s`**
-   and an **iteration count `i`** as well as a random, unique exchange id.
-2. **`p`**, **`s`** and **`i`** are used to generate the **HMAC key `x = PBKDF2(p, s, i)`**.
-3. **`O`** signs the **organizations public key `pub_o`** with **`x`**: **`sig_o = HMAC(x, pub_o)`**
-4. **`O`** sends **`s`**, **`i`**, **`pub_o`** and **`sig_o`** to the server **`S`**, along with the
-   exchange id and the recipients email address.
+1. The **organization owner `O`** chooses a **random passphrase `p`**, a
+   **random salt `s`** and an **iteration count `i`** as well as a random,
+   unique exchange id.
+2. **`p`**, **`s`** and **`i`** are used to generate the **HMAC key
+   `x = PBKDF2(p, s, i)`**.
+3. **`O`** signs the **organizations public key `pub_o`** with **`x`**:
+   **`sig_o = HMAC(x, pub_o)`**
+4. **`O`** sends **`s`**, **`i`**, **`pub_o`** and **`sig_o`** to the server
+   **`S`**, along with the exchange id and the recipients email address.
 5. The server stores the received values and sends the invitation link (which
    includes the exchange id) to **`I`** via email.
-6. **`I`** uses the exchange id to request **`s`**, **`i`**, **`pub_o`** and **`sig_o`** from **`S`**.
-7. **`I`** requests **`p`** from **`O`** via a separate (and optimally secure) channel of their
-   choice. This can be in person, via phone or any by other means.
+6. **`I`** uses the exchange id to request **`s`**, **`i`**, **`pub_o`** and
+   **`sig_o`** from **`S`**.
+7. **`I`** requests **`p`** from **`O`** via a separate (and optimally secure)
+   channel of their choice. This can be in person, via phone or any by other
+   means.
 8. **`I`** generates **`x = PBKDF2(p, s, i)`** using the obtained information.
 9. **`I`** verifies **`pub_o`** using **`x`** and **`sig_o`**.
-10. Upon successful verification, **`I`** signs their own **public key `pub_i`** using
-    **`x`**: **`sig_i = HMAC(x, pub_i)`**
-11. **`I`** sends **`pub_i`** and **`sig_i`** to **`S`**, which forwards them to **`O`**.
+10. Upon successful verification, **`I`** signs their own **public key `pub_i`**
+    using **`x`**: **`sig_i = HMAC(x, pub_i)`**
+11. **`I`** sends **`pub_i`** and **`sig_i`** to **`S`**, which forwards them to
+    **`O`**.
 12. **`O`** verifies **`pub_i`** using **`sig_i`** and **`x`**.
 
 ```
@@ -448,31 +461,32 @@ new member. The key exchange is performed as follows:
     included in the respective signatures to protect these from tempering as
     well.
 
--   Since `p` needs to be sufficiently short to be conveniently entered by
-    hand, it can potentially be guessed by eavesdroppers which would allow them
-    to successfully perform a man-in-the-middle attack by injecting their own
-    public key. This is mitigated by using a sufficiently large iteration count `i`
-    and invalidating key exchanges after a certain amount of time.
+-   Since `p` needs to be sufficiently short to be conveniently entered by hand,
+    it can potentially be guessed by eavesdroppers which would allow them to
+    successfully perform a man-in-the-middle attack by injecting their own
+    public key. This is mitigated by using a sufficiently large iteration count
+    `i` and invalidating key exchanges after a certain amount of time.
 
 -   Using a separate, direct communication channel for communicating the secret
-    passphrase not only mitigates the risk of man-in-the-middle attacks but
-    also means that the server `S` does not need to be explicitly trusted.
+    passphrase not only mitigates the risk of man-in-the-middle attacks but also
+    means that the server `S` does not need to be explicitly trusted.
     Furthermore, the risk of phishing attacks by a third party (including a
     malicious server admin) is greatly reduced since a direct, personal
     interaction between the parties is required.
 
--   Since some time may pass between steps **1.** and **7.**, **`p`** needs to be
-    stored securely for later reference. This is done by encrypting it with a
+-   Since some time may pass between steps **1.** and **7.**, **`p`** needs to
+    be stored securely for later reference. This is done by encrypting it with a
     dedicated AES "invites key" which is only accessible to organization owners.
     (See [Metadata and Cryptographic Keys](#metadata-and-cryptographic-keys).
 
 #### Adding Members
 
 Once the new member and organization have successfully exchanged public keys,
-these need to be stored in a way that allows both parties to be verify them later.
-The invitees public key (along with their identifying information) is signed
-by the organizations private key (only available to the organization owner) while
-the organizations public key is signed by the invitees own, dedicated HMAC key.
+these need to be stored in a way that allows both parties to be verify them
+later. The invitees public key (along with their identifying information) is
+signed by the organizations private key (only available to the organization
+owner) while the organizations public key is signed by the invitees own,
+dedicated HMAC key.
 
 ```
 ┏━━━━━━━━━━━━━━┓
@@ -544,15 +558,16 @@ A basic organization member has the following privileges.
 3. Update vault data of assigned vaults where write permissions have been
    granted explicitly
 
-All of these privileges are enforced by the server (e.g. a vaults encrypted
-data will only be provided to a member if they are assigned to that vault)
-while access to the plain text data stored in vaults is also restricted
-cryptographically through the encryption mechanism described in [Vaults](#vaults).
+All of these privileges are enforced by the server (e.g. a vaults encrypted data
+will only be provided to a member if they are assigned to that vault) while
+access to the plain text data stored in vaults is also restricted
+cryptographically through the encryption mechanism described in
+[Vaults](#vaults).
 
 ##### Admin
 
-In addition to the privileges granted to basic members, admins also have the following
-privileges:
+In addition to the privileges granted to basic members, admins also have the
+following privileges:
 
 1. Create and delete Vaults
 2. Assign vault access to groups and members directly
@@ -568,35 +583,39 @@ owners also have the following privileges:
 3. Update the organizations public/private key pair
 
 As described in a [previous section](#adding-members), adding a new member to
-the organization requires access to the organizations private key. As described in
-[Metadata and Cryptographic Keys](#metadata-and-cryptographic-keys), this access
-is restricted cryptographically to organization owners.
+the organization requires access to the organizations private key. As described
+in [Metadata and Cryptographic Keys](#metadata-and-cryptographic-keys), this
+access is restricted cryptographically to organization owners.
 
 ## Authentication And Data Transfer
 
 Even though all sensitive information in **padloc** is end-to-end encrypted and
 theoretically secure even in case of an insecure connection or even a
-compromised server, **padloc** still uses a robust authentication scheme to limit
-access to user data, ensure payload integrity and enforce user permissions.
-A variation of the [Secure Remote
-Password](https://tools.ietf.org/html/rfc2945) protocol is used to authenticate
-users and establish a secure connection between client and server without
-exposing the user's master password.
+compromised server, **padloc** still uses a robust authentication scheme to
+limit access to user data, ensure payload integrity and enforce user
+permissions. A variation of the
+[Secure Remote Password](https://tools.ietf.org/html/rfc2945) protocol is used
+to authenticate users and establish a secure connection between client and
+server without exposing the user's master password.
 
 ### User Signup
 
 Whenever a user creates a Padloc account, the following steps take place:
 
-1. Let **`u`** and **`p`** be the user's **email address** and **master password**, respectively.
+1. Let **`u`** and **`p`** be the user's **email address** and **master
+   password**, respectively.
 2. The **client `C`** sends **`u`** to the server **`S`**.
-3. The server sends an email **verification code `c`** to the user's email address.
+3. The server sends an email **verification code `c`** to the user's email
+   address.
 4. **`C`** chooses a **random salt `s`** and **iteration count `i`**
-5. **`C`** generates **`x = PBKDF2(p, s, i)`** and the **password verifier `v = v(x)`**\*
+5. **`C`** generates **`x = PBKDF2(p, s, i)`** and the **password verifier
+   `v = v(x)`**\*
 6. **`C`** sends **`u`**, **`v`**, **`s`**, **`i`** and **`c`** to **`S`**
-7. **`S`** verifies **`c`** and, if successful, stores **`u`**, **`v`**, **`s`** and **`i`** for later use.
+7. **`S`** verifies **`c`** and, if successful, stores **`u`**, **`v`**, **`s`**
+   and **`i`** for later use.
 
-The signup process is now complete and the stored values can be used to
-verify the users identity and to negotiate a common session key.
+The signup process is now complete and the stored values can be used to verify
+the users identity and to negotiate a common session key.
 
 ```
                   ┌──────────┐     ┌──────────┐
@@ -634,15 +653,16 @@ negotiated. This happens as follows:
 6. **`C`** generates **`x = PBKDF2(p, s, i)`**, **`K = K_client(x, a, B)`** and
    **`M = M(A, B, K)`**\*.
 7. **`C`** sends **`M`** to **`S`**.
-8. **`S`** generates its own **`K' = K_server(v, b, A)`** and **`M' = M(A, B, K')`**\*.
+8. **`S`** generates its own **`K' = K_server(v, b, A)`** and
+   **`M' = M(A, B, K')`**\*.
 9. **`S`** verifies that **`M == M'`** and therefore **`K == K'`**. If
    verification fails, the session negotiation is aborted.
 10. If successful, **`S`** stores **`K`** under the session id **`sid`**.
 11. **`S`** sends **`sid`** to **`C`**, which also stores it along with **`K`**
     for later use.
 
-Client and server now have a common and secret session key **`K`** which
-can be used for authenticating subsequent requests.
+Client and server now have a common and secret session key **`K`** which can be
+used for authenticating subsequent requests.
 
 ```
                     ┌──────────┐     ┌──────────┐
@@ -670,19 +690,19 @@ can be used for authenticating subsequent requests.
 
 ### Request Authentication
 
-Using the common session key **`K`** Client and Server can now authenticate
-each request as follows:
+Using the common session key **`K`** Client and Server can now authenticate each
+request as follows:
 
 1. Let **`sid`** and **`K`** be the previously negotiated session id and key.
-2. Let **`req`** be the intended request body and **`t1`** the time stamp at
-   the time of the request.
+2. Let **`req`** be the intended request body and **`t1`** the time stamp at the
+   time of the request.
 3. **`C`** generates the signature **`sig1 = HMAC(K, sid|t1|req)`**.
 4. **`C`** sends **`req`**, **`sid`**, **`t1`** and **`sig1`** to **`S`**.
 5. **`S`** verifies **`req`**, **`sid`** and **`t1`** using **`sig1`**. If
    verification fails, or if **`t1`** is older than a predetermined maximum
    request age, the request is rejected.
-6. Let **`res`** be the response body and **`t2`** the time stamp at the time
-   of the response.
+6. Let **`res`** be the response body and **`t2`** the time stamp at the time of
+   the response.
 7. **`S`** generates **`sig2 = HMAC(K, sid|t2|res)`**.
 8. **`S`** sends **`res`**, **`t2`** and **`sig2`** to **`C`**.
 9. **`C`** verifies **`res`**, **`sid`** and **`t2`** using **`sig2`**. If
@@ -707,22 +727,23 @@ each request as follows:
 ```
 
 **\*** For details on how **`v`**, **`a`**, **`A`**, **`b`**, **`B`**, **`K`**
-and **`M`** are generated, refer to [the SRP
-specification](https://tools.ietf.org/html/rfc2945#section-3)
+and **`M`** are generated, refer to
+[the SRP specification](https://tools.ietf.org/html/rfc2945#section-3)
 
 ### Notes
 
--   Even though **`v`** is based on **`p`**, it can not be used to guess the password in
-    case someone eavesdrops on the connection or if the server is compromised.
-    See [section 4 of the SRP
-    specification](https://tools.ietf.org/html/rfc2945#section-4) for details.
--   The session key **`K`** cannot be sniffed out since it is never transmitted. It
-    could theoretically be guessed from the request signature but with a key size
-    of 256 bits this is not really feasible either.
+-   Even though **`v`** is based on **`p`**, it can not be used to guess the
+    password in case someone eavesdrops on the connection or if the server is
+    compromised. See
+    [section 4 of the SRP specification](https://tools.ietf.org/html/rfc2945#section-4)
+    for details.
+-   The session key **`K`** cannot be sniffed out since it is never transmitted.
+    It could theoretically be guessed from the request signature but with a key
+    size of 256 bits this is not really feasible either.
 -   The salt and iteration count used for generating **`x`** as well as the
-    resulting authentication key are completely independent of the
-    corresponding values used for encrypting the accounts private key, even though
-    the derivation scheme and base passphrase are the same.
+    resulting authentication key are completely independent of the corresponding
+    values used for encrypting the accounts private key, even though the
+    derivation scheme and base passphrase are the same.
 -   Request authentication works both ways. Not only can the server verify the
     users identity and knowledge of their master password, the client can also
     verify the identity of the server.
@@ -738,10 +759,11 @@ This section covers various possible attack vectors and mitigation steps taken.
 
 ### Man-In-The-Middle Attacks
 
-A [man-in-the-middle
-attack](https://en.wikipedia.org/wiki/Man-in-the-middle_attack) is an attack
-where the attacker secretly relays the communication between two parties in
-order to eavesdrop on the connection and/or temper with messages in transit.
+A
+[man-in-the-middle attack](https://en.wikipedia.org/wiki/Man-in-the-middle_attack)
+is an attack where the attacker secretly relays the communication between two
+parties in order to eavesdrop on the connection and/or temper with messages in
+transit.
 
 MITM attacks may be launched in a multitude of ways, and even with technlogies
 like TLS, it is very hard to completely rule out that other parties may be
@@ -754,41 +776,44 @@ compromise the security of the application in any other way.
 -   Communication between the Padloc client and server is always secured through
     [Transport Layer Security](https://en.wikipedia.org/wiki/Transport_Layer_Security).
 -   No sensitive information is ever transmitted in plain text.
--   Transmitted data is protected from tampering through Padloc's strong [Authentication Mechanism](#authentication-and-data-transfer).
--   Padloc's [Key Exchange Mechanism](#trustless-server-mediated-key-exchange) is designed to be secure even over an untrusted connection.
+-   Transmitted data is protected from tampering through Padloc's strong
+    [Authentication Mechanism](#authentication-and-data-transfer).
+-   Padloc's [Key Exchange Mechanism](#trustless-server-mediated-key-exchange)
+    is designed to be secure even over an untrusted connection.
 
 ### Phishing
 
-With the addition of [Organizations And Shared
-Vaults](#organizations-and-shared-vaults) in Padloc 3, phishing has become a
-potential attack vector as well. Attackers may try to lure Padloc users into
-sharing sensitive information by inviting them to misleadingly named
-organizations which can be mistaken for an employer or friend. Users could then
-accidentally share data within vaults assigned to them.
+With the addition of
+[Organizations And Shared Vaults](#organizations-and-shared-vaults) in Padloc 3,
+phishing has become a potential attack vector as well. Attackers may try to lure
+Padloc users into sharing sensitive information by inviting them to misleadingly
+named organizations which can be mistaken for an employer or friend. Users could
+then accidentally share data within vaults assigned to them.
 
 However, the procedure for inviting and adding a new member to an organization
 is designed in a way that makes this very hard to accomplish, since it requires
-direct, personal coordination between both parties. See [Trustless
-Server-Mediated Key Exchange](#trustless-server-mediated-key-exchange) for more
-details.
+direct, personal coordination between both parties. See
+[Trustless Server-Mediated Key Exchange](#trustless-server-mediated-key-exchange)
+for more details.
 
 ### Guessing Master Passwords
 
-Padloc uses a combination of various [strong encryption
-algorithms](#cryptographic-primitives-and-parameters) to protect all sensitive
-data and cryptographic keys both at rest and during transmission. The **master
-password** acts as a universal key for this encryption scheme.
+Padloc uses a combination of various
+[strong encryption algorithms](#cryptographic-primitives-and-parameters) to
+protect all sensitive data and cryptographic keys both at rest and during
+transmission. The **master password** acts as a universal key for this
+encryption scheme.
 
 Master passwords are never stored anywhere and should only ever be known by the
 Padloc user themself. Unfortunately, since this means that in the majority of
-use cases the user will have to commit this password to memory, the "key space" of
-feasible passwords is relatively limited. Additionally, since master passwords
-are ultimately chosen by the user, no guarantee can be made to the strength or
-randomness of these passwords.
+use cases the user will have to commit this password to memory, the "key space"
+of feasible passwords is relatively limited. Additionally, since master
+passwords are ultimately chosen by the user, no guarantee can be made to the
+strength or randomness of these passwords.
 
 This means that master password are a prime-target for guessing attacks of all
-sorts and steps should be taken to make these attacks either infeasible or, at
-a very minimum, too costly to be worthwhile.
+sorts and steps should be taken to make these attacks either infeasible or, at a
+very minimum, too costly to be worthwhile.
 
 [[TODO]]
 
@@ -812,9 +837,9 @@ a very minimum, too costly to be worthwhile.
 
 ### Symmetric Encryption
 
-For all symmetric encryption operations, the [AES
-Cipher](https://en.wikipedia.org/wiki/Advanced_Encryption_Standard) is used in
-[GCM mode](https://en.wikipedia.org/wiki/Galois/Counter_Mode) with a key size
+For all symmetric encryption operations, the
+[AES Cipher](https://en.wikipedia.org/wiki/Advanced_Encryption_Standard) is used
+in [GCM mode](https://en.wikipedia.org/wiki/Galois/Counter_Mode) with a key size
 of **256 bits**.
 
 **Areas of use:**
@@ -827,8 +852,8 @@ of **256 bits**.
 
 For asymmetric encryption operations, the
 [RSA-OAEP](https://en.wikipedia.org/wiki/Optimal_asymmetric_encryption_padding)
-algorithm is used with a **modulus length** of **2048 bits** and the [SHA-256 hash
-function](https://en.wikipedia.org/wiki/SHA-2).
+algorithm is used with a **modulus length** of **2048 bits** and the
+[SHA-256 hash function](https://en.wikipedia.org/wiki/SHA-2).
 
 **Areas of use:**
 
@@ -836,8 +861,10 @@ function](https://en.wikipedia.org/wiki/SHA-2).
 
 ### Symmetric Signature Schemes
 
-For symmetric signature creation and verification, the [HMAC](https://en.wikipedia.org/wiki/HMAC) algorithm is used with a **key length** of **256 bits** and the [SHA-256 hash
-function](https://en.wikipedia.org/wiki/SHA-2).
+For symmetric signature creation and verification, the
+[HMAC](https://en.wikipedia.org/wiki/HMAC) algorithm is used with a **key
+length** of **256 bits** and the
+[SHA-256 hash function](https://en.wikipedia.org/wiki/SHA-2).
 
 **Areas of use:**
 
@@ -848,9 +875,11 @@ function](https://en.wikipedia.org/wiki/SHA-2).
 
 ### Asymmetric Signature Schems
 
-For asymmetric signature creation and verification, the [RSA-PSS](https://en.wikipedia.org/wiki/Probabilistic_signature_scheme) algorithm is
-used with a **modulus length** of **2048 bits**, a **salt length** of **256 bits** and the [SHA-256 hash
-function](https://en.wikipedia.org/wiki/SHA-2).
+For asymmetric signature creation and verification, the
+[RSA-PSS](https://en.wikipedia.org/wiki/Probabilistic_signature_scheme)
+algorithm is used with a **modulus length** of **2048 bits**, a **salt length**
+of **256 bits** and the
+[SHA-256 hash function](https://en.wikipedia.org/wiki/SHA-2).
 
 **Areas of use:**
 
@@ -861,8 +890,8 @@ function](https://en.wikipedia.org/wiki/SHA-2).
 
 For password-based key derivation, the
 [PBKDF2](https://en.wikipedia.org/wiki/PBKDF2) algorithm is used with the
-[SHA-256 hash function](https://en.wikipedia.org/wiki/SHA-2) and a **salt length**
-of **128 bits**. The iteration count varies by area of use.
+[SHA-256 hash function](https://en.wikipedia.org/wiki/SHA-2) and a **salt
+length** of **128 bits**. The iteration count varies by area of use.
 
 **Areas of use:**
 


### PR DESCRIPTION
- @padloc/server now supports loading configuration from a `.env` file
- Updated/added some npm scripts to improve ergonomics
- Updated existing readme files and added new ones for some packages

There is still some work to be done on documenting the different configuration options for the server, but I'd rather do this a little later since I'd like to get this merged so that we can merge the `v4` branch soon.