### PR TITLE
Add timingSafeEqual to CryptoProvider as better alternative for @padloc/core/encoding/equalCT

### DIFF
--- a/packages/app/src/lib/crypto.ts
+++ b/packages/app/src/lib/crypto.ts
@@ -115,6 +115,20 @@ export class WebCryptoProvider implements CryptoProvider {
         }
     }
 
+    async timingSafeEqual(a: Uint8Array, b: Uint8Array): Promise<boolean> {
+        const compareKey = await this.generateKey(new HMACKeyParams());
+        const hmacA = await this.sign(compareKey, a, new HMACParams());
+        const hmacB = await this.sign(compareKey, b, new HMACParams());
+
+        let match = true;
+
+        for (let i = 0; i < hmacA.length; i++) {
+            match = match && hmacA[i] === hmacB[i];
+        }
+
+        return hmacA.length === hmacB.length && match;
+    }
+
     private async _encryptAES(key: AESKey, data: Uint8Array, params: AESEncryptionParams): Promise<Uint8Array> {
         if (params.algorithm === "AES-CCM") {
             return SJCLProvider.encrypt(key, data, params);

--- a/packages/core/src/crypto.ts
+++ b/packages/core/src/crypto.ts
@@ -198,4 +198,9 @@ export interface CryptoProvider {
      * Creates a fingerprint from a given rsa public key
      */
     fingerprint(key: RSAPublicKey): Promise<Uint8Array>;
+
+    /**
+     * Compares two values without leaking timing information that would allow an attacker to guess one of the values
+     */
+    timingSafeEqual(a: Uint8Array, b: Uint8Array): Promise<boolean>;
 }

--- a/packages/core/src/encoding.ts
+++ b/packages/core/src/encoding.ts
@@ -499,17 +499,3 @@ export function equalBytes(a: Uint8Array, b: Uint8Array): boolean {
 
     return true;
 }
-
-/**
- * Checks two array-like objects for equality in constant time
- * (given that the `===` operator performs in constant time over all elements)
- */
-export function equalCT<T extends ArrayLike<any>>(a: T, b: T): boolean {
-    let match = true;
-
-    for (let i = 0; i < a.length; i++) {
-        match = match && a[i] === b[i];
-    }
-
-    return a.length === b.length && match;
-}

--- a/packages/core/src/otp.ts
+++ b/packages/core/src/otp.ts
@@ -1,4 +1,4 @@
-import { numToBytes, bytesToNum, equalCT } from "./encoding";
+import { numToBytes, bytesToNum, stringToBytes } from "./encoding";
 import { HMACParams } from "./crypto";
 import { getCryptoProvider as getProvider } from "./platform";
 import { base32ToBytes } from "./encoding";
@@ -56,7 +56,7 @@ export async function validateHotp(
     let matchFound = false;
     for (let c = counter - window; c <= counter + window; c++) {
         const t = await hotp(secret, c, opts);
-        matchFound = matchFound || equalCT(t, token);
+        matchFound = matchFound || (await getProvider().timingSafeEqual(stringToBytes(t), stringToBytes(token)));
     }
     return matchFound;
 }

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -1,4 +1,4 @@
-import { equalCT, Serializable, stringToBase64 } from "./encoding";
+import { Serializable, stringToBase64 } from "./encoding";
 import {
     API,
     StartCreateSessionParams,
@@ -51,7 +51,7 @@ import {
     Messenger,
 } from "./messenger";
 import { Server as SRPServer, SRPSession } from "./srp";
-import { DeviceInfo } from "./platform";
+import { DeviceInfo, getCryptoProvider } from "./platform";
 import { getIdFromEmail, uuid } from "./util";
 import { loadLanguage } from "@padloc/locale/src/translate";
 import { Logger, VoidLogger } from "./logging";
@@ -574,7 +574,7 @@ export class Controller extends API {
         // accounts master password. This also guarantees that the session key
         // computed by the client and server are identical an can be used for
         // authentication.
-        if (!equalCT(M, srp.M1!)) {
+        if (!(await getCryptoProvider().timingSafeEqual(M, srp.M1!))) {
             this.log("account.createSession", { success: false });
             throw new Err(ErrorCode.INVALID_CREDENTIALS);
         }
@@ -599,7 +599,7 @@ export class Controller extends API {
         // Add device to trusted devices
         if (
             this.context.device &&
-            !auth.trustedDevices.some(({ id }) => equalCT(id, this.context.device!.id)) &&
+            !auth.trustedDevices.some(({ id }) => id === this.context.device!.id) &&
             addTrustedDevice
         ) {
             auth.trustedDevices.push(this.context.device);

--- a/packages/core/src/stub-crypto-provider.ts
+++ b/packages/core/src/stub-crypto-provider.ts
@@ -142,4 +142,14 @@ export class StubCryptoProvider implements CryptoProvider {
         const extractedData = signature.slice(keyLength);
         return equal(key, extractedKey) && equal(data, extractedData);
     }
+
+    async timingSafeEqual(a: Uint8Array, b: Uint8Array): Promise<boolean> {
+        let match = true;
+
+        for (let i = 0; i < a.length; i++) {
+            match = match && a[i] === b[i];
+        }
+
+        return a.length === b.length && match;
+    }
 }

--- a/packages/server/src/crypto/node.ts
+++ b/packages/server/src/crypto/node.ts
@@ -13,6 +13,7 @@ import {
     createDecipheriv,
     publicEncrypt,
     privateDecrypt,
+    timingSafeEqual,
 } from "crypto";
 import {
     CryptoProvider,
@@ -32,7 +33,6 @@ import {
     PBKDF2Params,
 } from "@padloc/core/src/crypto";
 import { Err, ErrorCode } from "@padloc/core/src/error";
-import { equalCT } from "@padloc/core/src/encoding";
 
 // Converts hash algorithm name to a format that node can understand
 // E.g.: "SHA-256" => "sha256"
@@ -201,6 +201,10 @@ export class NodeCryptoProvider implements CryptoProvider {
         }
     }
 
+    async timingSafeEqual(a: Uint8Array, b: Uint8Array): Promise<boolean> {
+        return a.length === b.length && timingSafeEqual(a, b);
+    }
+
     private async _encryptAES(key: AESKey, data: Uint8Array, params: AESEncryptionParams): Promise<Uint8Array> {
         const [alg, mode] = params.algorithm.toLowerCase().split("-");
         const authTagLength = params.tagSize / 8;
@@ -283,7 +287,7 @@ export class NodeCryptoProvider implements CryptoProvider {
         params: HMACParams
     ): Promise<boolean> {
         const sig = await this._signHMAC(key, data, params);
-        return equalCT(sig, signature);
+        return this.timingSafeEqual(sig, signature);
     }
 
     private _signRSA(key: RSAPrivateKey, data: Uint8Array, params: RSASigningParams) {

--- a/packages/server/src/provisioning/stripe.ts
+++ b/packages/server/src/provisioning/stripe.ts
@@ -18,7 +18,7 @@ import { uuid } from "@padloc/core/src/util";
 import { Org } from "@padloc/core/src/org";
 import { createServer, IncomingMessage, ServerResponse } from "http";
 import { getCryptoProvider } from "@padloc/core/src/platform";
-import { base64ToBytes, bytesToBase64, equalCT, stringToBytes } from "@padloc/core/src/encoding";
+import { base64ToBytes, bytesToBase64, stringToBytes } from "@padloc/core/src/encoding";
 import { HMACKeyParams, HMACParams } from "@padloc/core/src/crypto";
 import { URLSearchParams } from "url";
 import { Account } from "@padloc/core/src/account";
@@ -785,14 +785,12 @@ export class StripeProvisioner extends BasicProvisioner {
         params.delete("sig");
         params.sort();
 
-        const sig1 = base64ToBytes(sig);
-        const sig2 = await getCryptoProvider().sign(
+        return getCryptoProvider().verify(
             base64ToBytes(this.config.portalSecret),
+            base64ToBytes(sig),
             stringToBytes(params.toString()),
             new HMACParams()
         );
-
-        return equalCT(sig1, sig2);
     }
 
     private async _getPortalUrl(customer: Stripe.Customer, action?: PortalAction, tier?: Tier) {


### PR DESCRIPTION
Replaces [@padloc/core/util/equalCT](https://github.com/padloc/padloc/blob/v4/packages/core/src/encoding.ts#L507) (which is not really constant-time) with true timing-safe comparison method as part of [CryptoProvider](https://github.com/padloc/padloc/blob/v4/packages/core/src/crypto.ts#L148).