### PR TITLE
Fix menu not being updated when changing vault name

### DIFF
--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -272,7 +272,7 @@ Cypress.Commands.add("v3_signup", (email: string) => {
         cy.get("pl-loading-button#submitPasswordButton").click({ force: true });
     });
 
-    cy.url().should("include", "/items");
+    cy.url({ timeout: 10000 }).should("include", "/items");
 });
 
 Cypress.Commands.add("v3_login", (email: string) => {

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -1954,9 +1954,17 @@ export class Server {
                 (async () => {
                     try {
                         const vault = await this.storage.get(Vault, vaultInfo.id);
-                        vault.name = vaultInfo.name;
-                        vault.org = org.info;
-                        await this.storage.save(vault);
+
+                        if (
+                            vaultInfo.name !== vault.name ||
+                            !vault.org ||
+                            Object.entries(vaultInfo).some(([key, value]) => vault.org![key] !== value)
+                        ) {
+                            vault.revision = await uuid();
+                            vault.name = vaultInfo.name;
+                            vault.org = org.info;
+                            await this.storage.save(vault);
+                        }
 
                         vaultInfo.revision = vault.revision;
                     } catch (e) {


### PR DESCRIPTION
Update vault revision when changing name or other meta data to make sure clients pull the updated version

Fixes #427