### PR TITLE
Enable SAML SSO for SCIM (Google Workspaces)

### DIFF
--- a/docs/examples/config/example.env
+++ b/docs/examples/config/example.env
@@ -287,7 +287,8 @@
 
 # PL_PROVISIONING_BACKEND=directory
 # PL_DIRECTORY_PROVIDERS=scim
-# PL_DIRECTORY_SCIM_PORT=[required]
+# PL_DIRECTORY_SCIM_URL=http://localhost:5000
+# PL_DIRECTORY_SCIM_PORT=5000
 
 # =============================================================================
 # SERVER
@@ -301,6 +302,7 @@
 # PL_SERVER_VERIFY_EMAIL_ON_SIGNUP=true
 # PL_SERVER_DEFAULT_AUTH_TYPES=email
 # PL_SERVER_DISABLE_SIGNUP=false
+# PL_SERVER_SCIM_SERVER_URL=http://localhost:5000
 
 
 # =============================================================================

--- a/docs/examples/scim/README.md
+++ b/docs/examples/scim/README.md
@@ -30,9 +30,11 @@ Workspaces is used below, but any other setup should be similar).
    note of the `SAML ACS URL` value, as you'll need it in step 4.
 3. Follow
    [Google's guide to create a custom SAML app](https://support.google.com/a/answer/6087519).
-4. Enter the proper `ACS URL` value you got from step 2, everything else you can
+4. Choose `EMAIL` as the `Name ID` format, and leave
+   `Basic Information > Primary email` as the `Name ID`.
+5. Enter the proper `ACS URL` value you got from step 2, everything else you can
    name as "Padloc" or something for yourself to identify.
-5. For the SAML attribute mapping, make sure you set:
+6. For the SAML attribute mapping, make sure you set:
 
 ```
 Primary email -> email
@@ -42,9 +44,15 @@ First name -> firstName
 Last name -> lastName
 ```
 
-6. When you test the SAML Login (via Test SAML Login), you should see a SCIM
-   response with your user details. You can now close this page and your user
-   will have been provisioned already.
+Note that group mapping isn't supported in this method.
+
+7. When you test the SAML Login (via Test SAML Login), you should be redirected
+   to the app with your account already provisioned, or see a SCIM response with
+   an error.
 
 That's it. For other users to be provisioned, they just need to login to the app
 via SSO, initiated from the Google Console (IdP).
+
+NOTE: If you see a `not_a_saml_app` error when trying to login via SSO, logout
+from your Google account and try again, as this is usually a problem with
+Google's account cache not knowing about the new app.

--- a/docs/examples/scim/README.md
+++ b/docs/examples/scim/README.md
@@ -1,4 +1,6 @@
-# SCIM ( with Active Directory ) Example
+# SCIM Example
+
+## With Active Directory (Microsoft / Outlook)
 
 These are simple instructions to setup SCIM provisioning with Active Directory
 (Azure Active Directory is used below, but any other setup should be similar).
@@ -10,10 +12,39 @@ These are simple instructions to setup SCIM provisioning with Active Directory
    step 4.
 3. In your Active Directory, create a new Enterprise application (you can name
    id "Padloc", for example) and choose Automatic provisioning.
-4. Enter the proper `Tenant URL` (you) and `Secret Token` values you got from
-   step 2.
+4. Enter the proper `Tenant URL` and `Secret Token` values you got from step 2.
 5. Test the connection, it should pass.
 
 That is it. You can now optionally try "Provision on demand" to manually
 provision some user, or simply "Start provisioning" to get it automatically
 synchronizing values every X minutes, depending on your setup.
+
+## With SAML SSO (Google Workspaces / Cloud Identity)
+
+These are simple instructions to setup SCIM provisioning with SAML SSO (Google
+Workspaces is used below, but any other setup should be similar).
+
+1. Make sure your server has SCIM support enabled (i.e.
+   `PL_PROVISIONING_BACKEND=directory` and `PL_DIRECTORY_PROVIDERS=scim`).
+2. Go to your organization's settings in Padloc and enable Directory Sync. Take
+   note of the `SAML ACS URL` value, as you'll need it in step 4.
+3. Follow
+   [Google's guide to create a custom SAML app](https://support.google.com/a/answer/6087519).
+4. Enter the proper `ACS URL` value you got from step 2, everything else you can
+   name as "Padloc" or something for yourself to identify.
+5. For the SAML attribute mapping, make sure you set:
+
+```
+Primary email -> email
+
+First name -> firstName
+
+Last name -> lastName
+```
+
+6. When you test the SAML Login (via Test SAML Login), you should see a SCIM
+   response with your user details. You can now close this page and your user
+   will have been provisioned already.
+
+That's it. For other users to be provisioned, they just need to login to the app
+via SSO, initiated from the Google Console (IdP).

--- a/packages/app/src/elements/org-settings.ts
+++ b/packages/app/src/elements/org-settings.ts
@@ -226,6 +226,7 @@ export class OrgSettingsView extends Routing(StateMixin(LitElement)) {
         const syncEnabled = org.directory.syncProvider !== "none";
         const scimUrl = (syncEnabled && org.directory.scim?.url) || "";
         const scimSecretToken = (syncEnabled && org.directory.scim?.secretToken) || "";
+        const samlsAcsUrl = `${scimUrl}/saml?token=${scimSecretToken}`;
 
         return html`
             <div class="vertical spacing layout fill-horizontally">
@@ -264,6 +265,18 @@ export class OrgSettingsView extends Routing(StateMixin(LitElement)) {
                                 <div class="tiny blue highlighted">${$l("Secret Token")}</div>
                                 <div class="small">
                                     <code>${scimSecretToken}</code>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div
+                            class="padded border-top click hover"
+                            @click=${() => setClipboard(samlsAcsUrl, $l("SAML ACS URL"))}
+                        >
+                            <div class="half-padded">
+                                <div class="tiny blue highlighted">${$l("SAML ACS URL")}</div>
+                                <div class="small">
+                                    <code>${samlsAcsUrl}</code>
                                 </div>
                             </div>
                         </div>

--- a/packages/server/src/provisioning/directory.ts
+++ b/packages/server/src/provisioning/directory.ts
@@ -17,9 +17,9 @@ export class DirectoryProvisioner extends BasicProvisioner implements DirectoryS
     ) {
         super(storage, config);
         this.config.default = new DefaultAccountProvisioning({
-            status: ProvisioningStatus.Active,
-            // statusLabel: "Access Denied",
-            // statusMessage: "You currently don't have access to this service. Please contact the service administrator.",
+            status: ProvisioningStatus.Unprovisioned,
+            statusLabel: "Access Denied",
+            statusMessage: "You currently don't have access to this service. Please contact the service administrator.",
         });
         for (const provider of providers) {
             provider.subscribe(this);

--- a/packages/server/src/provisioning/directory.ts
+++ b/packages/server/src/provisioning/directory.ts
@@ -17,9 +17,9 @@ export class DirectoryProvisioner extends BasicProvisioner implements DirectoryS
     ) {
         super(storage, config);
         this.config.default = new DefaultAccountProvisioning({
-            status: ProvisioningStatus.Unprovisioned,
-            statusLabel: "Access Denied",
-            statusMessage: "You currently don't have access to this service. Please contact the service administrator.",
+            status: ProvisioningStatus.Active,
+            // statusLabel: "Access Denied",
+            // statusMessage: "You currently don't have access to this service. Please contact the service administrator.",
         });
         for (const provider of providers) {
             provider.subscribe(this);

--- a/packages/server/src/scim.ts
+++ b/packages/server/src/scim.ts
@@ -180,9 +180,6 @@ export class ScimServer implements DirectoryProvider {
     }
 
     private _validateScimUser(user: ScimUser) {
-        // TODO: Remove this
-        console.log(JSON.stringify({ user }, null, 2));
-
         if (!this._getScimUserEmail(user)) {
             return "User must contain email";
         }
@@ -813,7 +810,7 @@ export class ScimServer implements DirectoryProvider {
         }
 
         // TODO: Remove this
-        console.log(JSON.stringify({ newUser }, null, 2));
+        console.log(JSON.stringify({ newUser, orgId }, null, 2));
 
         return this._createScimUser(newUser, orgId, secretToken, httpRes, true);
     }

--- a/packages/server/src/scim.ts
+++ b/packages/server/src/scim.ts
@@ -373,6 +373,7 @@ export class ScimServer implements DirectoryProvider {
 
             return this._sendResponse(httpRes, 201, newUser);
         } catch (error) {
+            console.error(error);
             return this._sendErrorResponse(httpRes, 500, "Unexpected Error");
         }
     }

--- a/packages/server/src/scim.ts
+++ b/packages/server/src/scim.ts
@@ -274,6 +274,10 @@ export class ScimServer implements DirectoryProvider {
             )
         );
 
+        // TODO: Remove this
+        console.log("======== _getDataFromScimRequest.matching");
+        console.log(JSON.stringify({ groups: matchUrl?.groups, basePath, url, configUrl: this.config.url }, null, 2));
+
         const type = matchUrl?.groups?.resourceType?.toLowerCase();
         const resourceType = (type === "users" ? "User" : type === "groups" ? "Group" : undefined) as
             | "Group"

--- a/packages/server/src/scim.ts
+++ b/packages/server/src/scim.ts
@@ -271,11 +271,13 @@ export class ScimServer implements DirectoryProvider {
         const filter = decodeURIComponent(url.searchParams.get("filter") || "").replace(/\+/g, " ");
 
         const matchUrl = url.pathname.match(
-            new RegExp(`${basePath}/(?<orgId>[^/]+)(?:/(?<resourceType>Users|Groups)(?:/(?<objectId>[^/?#]+))?)?`, "i")
+            new RegExp(
+                `${basePath}/(?<orgId>[^/]+)(?:/(?<resourceType>Users|Groups|saml)(?:/(?<objectId>[^/?#]+))?)?`,
+                "i"
+            )
         );
 
         const type = matchUrl?.groups?.resourceType?.toLowerCase();
-        console.log("type", type);
         const resourceType = (type === "users" ? "User" : type === "groups" ? "Group" : undefined) as
             | "Group"
             | "User"

--- a/packages/server/src/scim.ts
+++ b/packages/server/src/scim.ts
@@ -274,10 +274,6 @@ export class ScimServer implements DirectoryProvider {
             )
         );
 
-        // TODO: Remove this
-        console.log("======== _getDataFromScimRequest.matching");
-        console.log(JSON.stringify({ groups: matchUrl?.groups, basePath, url, configUrl: this.config.url }, null, 2));
-
         const type = matchUrl?.groups?.resourceType?.toLowerCase();
         const resourceType = (type === "users" ? "User" : type === "groups" ? "Group" : undefined) as
             | "Group"
@@ -334,7 +330,7 @@ export class ScimServer implements DirectoryProvider {
                 // Just redirect and don't error out for SAML if this user already exists
                 if (isComingFromSaml) {
                     httpRes.statusCode = 302;
-                    httpRes.setHeader("Location", "/");
+                    httpRes.setHeader("Location", `/start?email=${email}`);
                     httpRes.end();
                     return;
                 }
@@ -369,7 +365,7 @@ export class ScimServer implements DirectoryProvider {
             // SAML should redirect to the homepage
             if (isComingFromSaml) {
                 httpRes.statusCode = 302;
-                httpRes.setHeader("Location", "/");
+                httpRes.setHeader("Location", `/start?email=${email}`);
                 httpRes.end();
                 return;
             }


### PR DESCRIPTION
This adds support for integrating SCIM with Google Workspaces (or Cloud Identity) via SAML SSO.

Basically, when someone initiates SSO from their provider, it'll go to the right URL with the authorization info (once authorized in the provider), and we'll take that information, transform to a SCIM (new user) request, and parse that in.

It's not very pretty, but it works. This needs to be tested and still needs some polish (redirect to the start page once the user has been created or already exists).

As a reference, some things I tried that did not work, and some other interesting bits of information:
- [Cloud Identity](https://cloud.google.com/identity) (it's different from Google Workspaces, and does similar tihngs)
- And [the only supported architectures to integrate with their directory](https://cloud.google.com/architecture/identity/reference-architectures)
- Their [AD instructions](https://cloud.google.com/architecture/identity/preparing-your-g-suite-or-cloud-identity-account) are similar to ours, which is nice.
- [LDAP would be quite convoluted to setup](https://support.google.com/a/answer/9048434?authuser=2), and requires Business Plus or greater, which starts at roughly €15 / month / user.