### PR TITLE
Fix occasional non-focus extension popup in Firefox

### DIFF
--- a/.github/workflows/build-web-extension.yml
+++ b/.github/workflows/build-web-extension.yml
@@ -54,7 +54,7 @@ jobs:
                   name: padloc-web-extension-${{ github.sha }}-signed.xpi
                   path: packages/extension/dist/web-ext-artifacts/*.xpi
                   if-no-files-found: error
-            - name: Archive Unsigned Web Extension (Chrome)
+            - name: Archive Unsigned Web Extension (Chrome/Edge)
               uses: actions/upload-artifact@v2
               with:
                   name: padloc-web-extension-${{ github.sha }}-unsigned
@@ -63,19 +63,19 @@ jobs:
                       !packages/extension/dist/web-ext-artifacts
                       !packages/extension/dist/*.xpi
                   if-no-files-found: error
-            - name: Build ZIP for signing Chrome Extension
+            - name: Build ZIP for signing Chrome/Edge Extension
               uses: cardinalby/webext-buildtools-pack-extension-dir-action@v1
               with:
                   extensionDir: packages/extension/dist
                   zipFilePath: packages/extension/padloc.zip
                   zipIgnore: web-ext-artifacts/**|*.xpi
-            - name: Sign for Chrome
+            - name: Sign for Chrome/Edge
               uses: cardinalby/webext-buildtools-chrome-crx-action@v2
               with:
                   zipFilePath: packages/extension/padloc.zip
                   crxFilePath: packages/extension/padloc-signed.crx
                   privateKey: ${{ secrets.PL_WEB_EXTENSION_CHROME_CRX_PRIVATE_KEY }}
-            - name: Archive Signed Web Extension (Chrome)
+            - name: Archive Signed Web Extension (Chrome/Edge)
               uses: actions/upload-artifact@v2
               with:
                   name: padloc-web-extension-${{ github.sha }}-signed.crx

--- a/packages/extension/src/popup.ts
+++ b/packages/extension/src/popup.ts
@@ -6,8 +6,17 @@ import { ExtensionPlatform } from "./platform";
 
     await import("./app");
 
+    function focusWindow() {
+        if (document.visibilityState !== "hidden") {
+            window.focus();
+        }
+    }
+
     window.onload = () => {
         const app = document.createElement("pl-extension-app");
         document.body.appendChild(app);
+
+        setTimeout(focusWindow, 100);
+        setTimeout(focusWindow, 250);
     };
 })();


### PR DESCRIPTION
Fixes #482

While the solution isn't ideal, there isn't much more to do, other than not using a JS framework to render HTML, as per https://bugzilla.mozilla.org/show_bug.cgi?id=1324255

This also fixes some text on the web extension build, to make it clearer Edge is also supported.

I tested this throughout the day without ever getting the same problem (I did get it with just the `100` timeout), and did not notice any side effects (auto-focus for the password field works fine and if I start typing really fast, also noticed no issues in Firefox nor Chrome).