### PR TITLE
Desktop lock on suspend

### DIFF
--- a/packages/app/src/mixins/auto-lock.ts
+++ b/packages/app/src/mixins/auto-lock.ts
@@ -18,6 +18,7 @@ export function AutoLock<B extends Constructor<Object>>(baseClass: B) {
             document.addEventListener("keydown", () => this._startTimer());
             document.addEventListener("pause", () => this._pause());
             document.addEventListener("resume", () => this._resume());
+            document.addEventListener("lock-app", () => this._doLock());
         }
 
         _cancelAutoLock() {

--- a/packages/electron/src/platform.ts
+++ b/packages/electron/src/platform.ts
@@ -1,4 +1,13 @@
+import { ipcRenderer } from "electron";
 import { Platform } from "@padloc/core/src/platform";
 import { WebPlatform } from "@padloc/app/src/lib/platform";
 
-export class ElectronPlatform extends WebPlatform implements Platform {}
+export class ElectronPlatform extends WebPlatform implements Platform {
+    constructor() {
+        super();
+
+        ipcRenderer.on("electron-lock-app", () => {
+            window.document.dispatchEvent(new CustomEvent("lock-app"));
+        });
+    }
+}

--- a/packages/electron/webpack.config.js
+++ b/packages/electron/webpack.config.js
@@ -1,5 +1,6 @@
 const { resolve, join } = require("path");
 const { EnvironmentPlugin } = require("webpack");
+const HtmlWebpackPlugin = require("html-webpack-plugin");
 
 const rootDir = resolve(__dirname, "../..");
 const assetsDir = resolve(rootDir, process.env.PL_ASSETS_DIR || "assets");
@@ -38,6 +39,10 @@ module.exports = [
                 PL_APP_NAME: name,
                 PL_VENDOR_VERSION: version,
                 PL_TERMS_OF_SERVICE: terms_of_service,
+            }),
+            new HtmlWebpackPlugin({
+                title: name,
+                template: resolve(__dirname, "src/index.html"),
             }),
             {
                 apply(compiler) {


### PR DESCRIPTION
Related to #211

Note that this attempt doesn't quite work as the app doesn't load properly in Electron, and I eventually stopped trying to, since it's turning into a lot of effort. I just wanted it "documented".

There are to options to close #211:

1. When we detect the system is suspending/locking, shutdown/quit the app. This won't require any communication with the PWA.
2. We implement something like [`electron-safe-ipc`](https://www.npmjs.com/package/electron-safe-ipc) directly in the PWA, so electron can send the lock event to it.

Option 1 is not a great UX, but does handle the security aspect.

Option 2 is a much better UX, but introduces a new dependency that is only _relevant_ when the app's used via Electron.

What do you think @MaKleSoft ?