### PR TITLE
Allow selectively disabling all billing functionality on certain platforms

### DIFF
--- a/packages/app/src/elements/alert-dialog.ts
+++ b/packages/app/src/elements/alert-dialog.ts
@@ -3,6 +3,7 @@ import { html, css, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { Dialog } from "./dialog";
 import "./button";
+import "./icon";
 
 const defaultButtonLabel = $l("OK");
 
@@ -20,6 +21,7 @@ export interface AlertOptions {
     maxWidth?: string;
     width?: string;
     hideOnDocumentVisibilityChange?: boolean;
+    zIndex?: number;
 }
 
 @customElement("pl-alert-dialog")
@@ -119,6 +121,7 @@ export class AlertDialog extends Dialog<AlertOptions, number> {
         maxWidth,
         width,
         hideOnDocumentVisibilityChange = false,
+        zIndex = 10,
     }: AlertOptions = {}): Promise<number> {
         this.message = message;
         this.dialogTitle = title;
@@ -137,6 +140,7 @@ export class AlertDialog extends Dialog<AlertOptions, number> {
 
         await this.updateComplete;
 
+        this.style.zIndex = zIndex.toString();
         this._inner.style.setProperty("--pl-dialog-max-width", maxWidth || "inherit");
         this._inner.style.setProperty("--pl-dialog-width", width || "inherit");
 

--- a/packages/app/src/lib/platform.ts
+++ b/packages/app/src/lib/platform.ts
@@ -95,6 +95,7 @@ export class WebPlatform extends StubPlatform implements Platform {
                 browser.name && browser.name !== "Electron"
                     ? $l("{0} on {1}", browser.name, platform)
                     : $l("{0} Device", platform),
+            runtime: "web",
         });
     }
 

--- a/packages/app/src/lib/provisioning.ts
+++ b/packages/app/src/lib/provisioning.ts
@@ -39,6 +39,7 @@ async function alertMessage(message: string | RichContent, action?: { label: str
             type: !action ? "choice" : "info",
             title,
             hideOnDocumentVisibilityChange: true,
+            zIndex: 20,
         }
     );
     if (action && choice === 0) {

--- a/packages/cordova/package-lock.json
+++ b/packages/cordova/package-lock.json
@@ -8,7 +8,6 @@
             "name": "@padloc/cordova",
             "version": "4.0.0",
             "dependencies": {
-                "cordova-android": "10.1.0",
                 "cordova-clipboard": "1.3.0",
                 "cordova-ios": "6.2.0",
                 "cordova-plugin-add-swift-support": "2.0.2",
@@ -32,6 +31,7 @@
                 "@types/cordova-plugin-qrscanner": "1.0.31",
                 "clean-webpack-plugin": "3.0.0",
                 "cordova": "11.0.0",
+                "cordova-android": "^10.1.2",
                 "css-loader": "5.2.6",
                 "dotenv": "10.0.0",
                 "file-loader": "6.2.0",
@@ -756,6 +756,7 @@
             "version": "1.7.0",
             "resolved": "https://registry.npmjs.org/android-versions/-/android-versions-1.7.0.tgz",
             "integrity": "sha512-TCy4b8Dk8YS6A23ZPfhSKqK66JHFq0D8avGYiwvYpjno6HrrcI0DRgHx9+jtkvWYmrsE2vQWgbHJhvGGhhOb0g==",
+            "dev": true,
             "dependencies": {
                 "semver": "^5.7.1"
             }
@@ -764,6 +765,7 @@
             "version": "5.7.1",
             "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
             "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+            "dev": true,
             "bin": {
                 "semver": "bin/semver"
             }
@@ -1852,9 +1854,10 @@
             }
         },
         "node_modules/cordova-android": {
-            "version": "10.1.0",
-            "resolved": "https://registry.npmjs.org/cordova-android/-/cordova-android-10.1.0.tgz",
-            "integrity": "sha512-nkVh8VMDWoDmvWaQav/sF3Q7N9ZpRRNBJduDhjCOMwYUF/6q2526i/Jb/wJLdXmetBNh+THkGolcTBi9i+1UzA==",
+            "version": "10.1.2",
+            "resolved": "https://registry.npmjs.org/cordova-android/-/cordova-android-10.1.2.tgz",
+            "integrity": "sha512-F28+NvgKO4ZhKFkqctCOh62mhVoNyUuRQh/F/nqp+Sti4ODv2rUa6UeW18khhdYTjlDeihHQsPqxvB7mI6fVYA==",
+            "dev": true,
             "dependencies": {
                 "android-versions": "^1.7.0",
                 "cordova-common": "^4.0.2",
@@ -1873,9 +1876,10 @@
             }
         },
         "node_modules/cordova-android/node_modules/fs-extra": {
-            "version": "10.0.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
-            "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+            "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+            "dev": true,
             "dependencies": {
                 "graceful-fs": "^4.2.0",
                 "jsonfile": "^6.0.1",
@@ -2963,6 +2967,7 @@
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
             "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+            "dev": true,
             "dependencies": {
                 "cross-spawn": "^7.0.3",
                 "get-stream": "^6.0.0",
@@ -3360,6 +3365,7 @@
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
             "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+            "dev": true,
             "engines": {
                 "node": ">=10"
             },
@@ -3757,6 +3763,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
             "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+            "dev": true,
             "engines": {
                 "node": ">=10.17.0"
             }
@@ -4312,6 +4319,7 @@
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
             "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+            "dev": true,
             "engines": {
                 "node": ">=8"
             }
@@ -4341,6 +4349,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
             "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+            "dev": true,
             "engines": {
                 "node": ">=8"
             },
@@ -4752,7 +4761,8 @@
         "node_modules/merge-stream": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-            "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
+            "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+            "dev": true
         },
         "node_modules/merge2": {
             "version": "1.4.1",
@@ -4820,6 +4830,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
             "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+            "dev": true,
             "engines": {
                 "node": ">=6"
             }
@@ -5225,6 +5236,7 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
             "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+            "dev": true,
             "dependencies": {
                 "path-key": "^3.0.0"
             },
@@ -5321,6 +5333,7 @@
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
             "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+            "dev": true,
             "dependencies": {
                 "mimic-fn": "^2.1.0"
             },
@@ -5908,7 +5921,8 @@
         "node_modules/properties-parser": {
             "version": "0.3.1",
             "resolved": "https://registry.npmjs.org/properties-parser/-/properties-parser-0.3.1.tgz",
-            "integrity": "sha1-ExbpU5/7/ZOEXjabIRAiq9R4dxo=",
+            "integrity": "sha512-AkSQxQAviJ89x4FIxOyHGfO3uund0gvYo7lfD0E+Gp7gFQKrTNgtoYQklu8EhrfHVZUzTwKGZx2r/KDSfnljcA==",
+            "dev": true,
             "dependencies": {
                 "string.prototype.codepointat": "^0.2.0"
             },
@@ -6713,7 +6727,8 @@
         "node_modules/signal-exit": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-            "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
+            "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
+            "dev": true
         },
         "node_modules/simctl": {
             "version": "2.0.3",
@@ -7041,7 +7056,8 @@
         "node_modules/string.prototype.codepointat": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/string.prototype.codepointat/-/string.prototype.codepointat-0.2.1.tgz",
-            "integrity": "sha512-2cBVCj6I4IOvEnjgO/hWqXjqBGsY+zwPmHl12Srk9IXSZ56Jwwmy+66XO5Iut/oQVR7t5ihYdLB0GMa4alEUcg=="
+            "integrity": "sha512-2cBVCj6I4IOvEnjgO/hWqXjqBGsY+zwPmHl12Srk9IXSZ56Jwwmy+66XO5Iut/oQVR7t5ihYdLB0GMa4alEUcg==",
+            "dev": true
         },
         "node_modules/stringify-package": {
             "version": "1.0.1",
@@ -7073,6 +7089,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
             "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+            "dev": true,
             "engines": {
                 "node": ">=6"
             }
@@ -7594,6 +7611,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
             "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
+            "dev": true,
             "engines": {
                 "node": ">=8"
             }
@@ -8849,6 +8867,7 @@
             "version": "1.7.0",
             "resolved": "https://registry.npmjs.org/android-versions/-/android-versions-1.7.0.tgz",
             "integrity": "sha512-TCy4b8Dk8YS6A23ZPfhSKqK66JHFq0D8avGYiwvYpjno6HrrcI0DRgHx9+jtkvWYmrsE2vQWgbHJhvGGhhOb0g==",
+            "dev": true,
             "requires": {
                 "semver": "^5.7.1"
             },
@@ -8856,7 +8875,8 @@
                 "semver": {
                     "version": "5.7.1",
                     "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+                    "dev": true
                 }
             }
         },
@@ -9697,9 +9717,10 @@
             }
         },
         "cordova-android": {
-            "version": "10.1.0",
-            "resolved": "https://registry.npmjs.org/cordova-android/-/cordova-android-10.1.0.tgz",
-            "integrity": "sha512-nkVh8VMDWoDmvWaQav/sF3Q7N9ZpRRNBJduDhjCOMwYUF/6q2526i/Jb/wJLdXmetBNh+THkGolcTBi9i+1UzA==",
+            "version": "10.1.2",
+            "resolved": "https://registry.npmjs.org/cordova-android/-/cordova-android-10.1.2.tgz",
+            "integrity": "sha512-F28+NvgKO4ZhKFkqctCOh62mhVoNyUuRQh/F/nqp+Sti4ODv2rUa6UeW18khhdYTjlDeihHQsPqxvB7mI6fVYA==",
+            "dev": true,
             "requires": {
                 "android-versions": "^1.7.0",
                 "cordova-common": "^4.0.2",
@@ -9715,9 +9736,10 @@
             },
             "dependencies": {
                 "fs-extra": {
-                    "version": "10.0.0",
-                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
-                    "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
+                    "version": "10.1.0",
+                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+                    "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+                    "dev": true,
                     "requires": {
                         "graceful-fs": "^4.2.0",
                         "jsonfile": "^6.0.1",
@@ -10525,6 +10547,7 @@
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
             "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+            "dev": true,
             "requires": {
                 "cross-spawn": "^7.0.3",
                 "get-stream": "^6.0.0",
@@ -10837,7 +10860,8 @@
         "get-stream": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-            "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="
+            "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+            "dev": true
         },
         "getpass": {
             "version": "0.1.7",
@@ -11132,7 +11156,8 @@
         "human-signals": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
-            "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw=="
+            "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+            "dev": true
         },
         "humanize-ms": {
             "version": "1.2.1",
@@ -11541,7 +11566,8 @@
         "is-path-inside": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
-            "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ=="
+            "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+            "dev": true
         },
         "is-plain-object": {
             "version": "2.0.4",
@@ -11563,7 +11589,8 @@
         "is-stream": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-            "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="
+            "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+            "dev": true
         },
         "is-typedarray": {
             "version": "1.0.0",
@@ -11892,7 +11919,8 @@
         "merge-stream": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-            "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
+            "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+            "dev": true
         },
         "merge2": {
             "version": "1.4.1",
@@ -11938,7 +11966,8 @@
         "mimic-fn": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-            "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
+            "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+            "dev": true
         },
         "mimic-response": {
             "version": "1.0.1",
@@ -12254,6 +12283,7 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
             "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+            "dev": true,
             "requires": {
                 "path-key": "^3.0.0"
             }
@@ -12329,6 +12359,7 @@
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
             "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+            "dev": true,
             "requires": {
                 "mimic-fn": "^2.1.0"
             }
@@ -12760,7 +12791,8 @@
         "properties-parser": {
             "version": "0.3.1",
             "resolved": "https://registry.npmjs.org/properties-parser/-/properties-parser-0.3.1.tgz",
-            "integrity": "sha1-ExbpU5/7/ZOEXjabIRAiq9R4dxo=",
+            "integrity": "sha512-AkSQxQAviJ89x4FIxOyHGfO3uund0gvYo7lfD0E+Gp7gFQKrTNgtoYQklu8EhrfHVZUzTwKGZx2r/KDSfnljcA==",
+            "dev": true,
             "requires": {
                 "string.prototype.codepointat": "^0.2.0"
             }
@@ -13374,7 +13406,8 @@
         "signal-exit": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-            "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
+            "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
+            "dev": true
         },
         "simctl": {
             "version": "2.0.3",
@@ -13617,7 +13650,8 @@
         "string.prototype.codepointat": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/string.prototype.codepointat/-/string.prototype.codepointat-0.2.1.tgz",
-            "integrity": "sha512-2cBVCj6I4IOvEnjgO/hWqXjqBGsY+zwPmHl12Srk9IXSZ56Jwwmy+66XO5Iut/oQVR7t5ihYdLB0GMa4alEUcg=="
+            "integrity": "sha512-2cBVCj6I4IOvEnjgO/hWqXjqBGsY+zwPmHl12Srk9IXSZ56Jwwmy+66XO5Iut/oQVR7t5ihYdLB0GMa4alEUcg==",
+            "dev": true
         },
         "stringify-package": {
             "version": "1.0.1",
@@ -13642,7 +13676,8 @@
         "strip-final-newline": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-            "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA=="
+            "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+            "dev": true
         },
         "strip-json-comments": {
             "version": "2.0.1",
@@ -14006,7 +14041,8 @@
         "untildify": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
-            "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw=="
+            "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
+            "dev": true
         },
         "update-notifier": {
             "version": "5.1.0",

--- a/packages/cordova/package.json
+++ b/packages/cordova/package.json
@@ -40,7 +40,6 @@
     "dependencies": {
         "@padloc/app": "4.0.0",
         "@padloc/core": "4.0.0",
-        "cordova-android": "10.1.0",
         "cordova-clipboard": "1.3.0",
         "cordova-ios": "6.2.0",
         "cordova-plugin-add-swift-support": "2.0.2",
@@ -64,6 +63,7 @@
         "@types/cordova-plugin-qrscanner": "1.0.31",
         "clean-webpack-plugin": "3.0.0",
         "cordova": "11.0.0",
+        "cordova-android": "10.1.2",
         "css-loader": "5.2.6",
         "dotenv": "10.0.0",
         "file-loader": "6.2.0",

--- a/packages/cordova/src/platform.ts
+++ b/packages/cordova/src/platform.ts
@@ -49,6 +49,7 @@ export class CordovaPlatform extends WebPlatform implements Platform {
             platform,
             osVersion,
             description: appleDeviceNames[model] || model,
+            runtime: "cordova",
         });
     }
 

--- a/packages/core/src/platform.ts
+++ b/packages/core/src/platform.ts
@@ -47,6 +47,8 @@ export class DeviceInfo extends Serializable {
 
     description: string = $l("Unknown Device");
 
+    runtime: string = "";
+
     constructor(props?: Partial<DeviceInfo>) {
         super();
         props && Object.assign(this, props);

--- a/packages/core/src/provisioning.ts
+++ b/packages/core/src/provisioning.ts
@@ -3,6 +3,7 @@ import { Config, ConfigParam } from "./config";
 import { AsSerializable, Serializable } from "./encoding";
 import { Err, ErrorCode } from "./error";
 import { Org, OrgID, OrgInfo } from "./org";
+import { Session } from "./session";
 import { Storable, Storage } from "./storage";
 import { getIdFromEmail } from "./util";
 
@@ -215,7 +216,7 @@ export class Provisioning extends Serializable {
 }
 
 export interface Provisioner {
-    getProvisioning(params: { email: string; accountId?: AccountID }): Promise<Provisioning>;
+    getProvisioning(params: { email: string; accountId?: AccountID }, session?: Session): Promise<Provisioning>;
     accountDeleted(params: { email: string; accountId?: AccountID }): Promise<void>;
     orgDeleted(params: OrgInfo): Promise<void>;
     orgOwnerChanged(

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -199,13 +199,11 @@ export class Controller extends API {
         // Get account associated with this session
         const account = await this.storage.get(Account, session.account);
         const auth = await this._getAuth(account.email);
-        const provisioning = await this.provisioner.getProvisioning(auth);
 
         // Store account and session on context
         ctx.session = session;
         ctx.account = account;
         ctx.auth = auth;
-        ctx.provisioning = provisioning;
         ctx.location = req.location;
 
         // Update session info
@@ -220,6 +218,8 @@ export class Controller extends API {
         } else {
             auth.sessions.push(session.info);
         }
+
+        ctx.provisioning = await this.provisioner.getProvisioning(auth, session);
 
         await Promise.all([this.storage.save(session), this.storage.save(account), this.storage.save(auth)]);
     }

--- a/packages/electron/src/platform.ts
+++ b/packages/electron/src/platform.ts
@@ -1,4 +1,10 @@
 import { Platform } from "@padloc/core/src/platform";
 import { WebPlatform } from "@padloc/app/src/lib/platform";
 
-export class ElectronPlatform extends WebPlatform implements Platform {}
+export class ElectronPlatform extends WebPlatform implements Platform {
+    async getDeviceInfo() {
+        const device = await super.getDeviceInfo();
+        device.runtime = "electron";
+        return device;
+    }
+}

--- a/packages/extension/src/platform.ts
+++ b/packages/extension/src/platform.ts
@@ -12,6 +12,7 @@ export class ExtensionPlatform extends WebPlatform {
     async getDeviceInfo() {
         const info = await super.getDeviceInfo();
         info.description = `${info.browser} extension on ${info.platform}`;
+        info.runtime = "extension";
         return info;
     }
 }

--- a/packages/server/src/platform/node.ts
+++ b/packages/server/src/platform/node.ts
@@ -3,4 +3,10 @@ import { NodeCryptoProvider } from "../crypto/node";
 
 export class NodePlatform extends StubPlatform implements Platform {
     crypto = new NodeCryptoProvider();
+
+    async getDeviceInfo() {
+        const info = await super.getDeviceInfo();
+        info.runtime = "node";
+        return info;
+    }
 }

--- a/packages/server/src/provisioning/stripe.ts
+++ b/packages/server/src/provisioning/stripe.ts
@@ -359,9 +359,7 @@ export class StripeProvisioner extends BasicProvisioner {
                 email,
                 expand: ["data.subscriptions", "data.tax_ids"],
             });
-            customer = existingCustomers.data.find(
-                (c) => !c.metadata.org && (!c.metadata.account || c.metadata.account === accountId)
-            );
+            customer = existingCustomers.data.find((c) => !c.metadata.account || c.metadata.account === accountId);
         }
 
         // Create a new customer

--- a/packages/server/src/provisioning/stripe.ts
+++ b/packages/server/src/provisioning/stripe.ts
@@ -23,6 +23,7 @@ import { base64ToBytes, bytesToBase64, stringToBytes } from "@padloc/core/src/en
 import { HMACKeyParams, HMACParams } from "@padloc/core/src/crypto";
 import { URLSearchParams } from "url";
 import { Account } from "@padloc/core/src/account";
+import { Session } from "@padloc/core/src/session";
 
 export class StripeProvisionerConfig extends BasicProvisionerConfig {
     @ConfigParam("string", true)
@@ -48,6 +49,9 @@ export class StripeProvisionerConfig extends BasicProvisionerConfig {
 
     @ConfigParam("number")
     forceSyncAfter: number = 24 * 60 * 60;
+
+    @ConfigParam("string[]")
+    disableBillingOn = ["ios", "android"];
 }
 
 enum Tier {
@@ -218,8 +222,8 @@ export class StripeProvisioner extends BasicProvisioner {
         }
     }
 
-    async getProvisioning(opts: { email: string; accountId?: string | undefined }) {
-        const provisioning = await super.getProvisioning(opts);
+    async getProvisioning(opts: { email: string; accountId?: string | undefined }, session?: Session) {
+        let provisioning = await super.getProvisioning(opts);
         if (
             provisioning.account.accountId &&
             (!provisioning.account.metaData?.customer ||
@@ -228,7 +232,34 @@ export class StripeProvisioner extends BasicProvisioner {
         ) {
             await this._syncBilling(provisioning);
         }
-        return super.getProvisioning(opts);
+
+        provisioning = await super.getProvisioning(opts);
+
+        const platform = session?.device?.platform?.toLowerCase() || "";
+        const runtime = session?.device?.runtime;
+        if (runtime === "cordova" && this.config.disableBillingOn.includes(platform)) {
+            for (const feature of Object.values(provisioning.account.features)) {
+                if (feature.disabled) {
+                    feature.message = {
+                        type: "html",
+                        content: html`
+                            <div style="max-width: 20em">
+                                <div class="large text-centering semibold">
+                                    <i class="fa-ban"></i> Feature Not Available
+                                </div>
+                                <div class="top-margined">
+                                    This feature is not available on this platform yet. Please use the
+                                    <a href="https://web.padloc.app">web app</a> instead!
+                                </div>
+                            </div>
+                        `,
+                    };
+                    feature.actionUrl = "https://web.padloc.app";
+                    feature.actionLabel = "Open Web App";
+                }
+            }
+        }
+        return provisioning;
     }
 
     async orgOwnerChanged(

--- a/packages/tauri/src/platform.ts
+++ b/packages/tauri/src/platform.ts
@@ -1,7 +1,10 @@
-import { Platform } from "@padloc/core/src/platform";
+import { DeviceInfo, Platform } from "@padloc/core/src/platform";
 import { WebPlatform } from "@padloc/app/src/lib/platform";
-// import { MemoryStorage } from "@padloc/core/src/storage";
 
 export class TauriPlatform extends WebPlatform implements Platform {
-    // storage = new MemoryStorage();
+    async getDeviceInfo() {
+        const device = await super.getDeviceInfo();
+        device.runtime = "tauri";
+        return device;
+    }
 }

--- a/packages/tauri/src/platform.ts
+++ b/packages/tauri/src/platform.ts
@@ -1,4 +1,4 @@
-import { DeviceInfo, Platform } from "@padloc/core/src/platform";
+import { Platform } from "@padloc/core/src/platform";
 import { WebPlatform } from "@padloc/app/src/lib/platform";
 
 export class TauriPlatform extends WebPlatform implements Platform {


### PR DESCRIPTION
Title says it all. This will allow us to disable all billing-related functionality and references on certain platforms. For people on the free plan, using premium features will simply display a message saying the feature is not available on their platform yet and to use the web app instead. Once they've upgraded to premium, those features will be available on those platforms as well (but without a way to upgrade/downgrade etc).