### PR TITLE
Fix publishing snap in GitHub release

### DIFF
--- a/packages/electron/prepare-build.js
+++ b/packages/electron/prepare-build.js
@@ -58,11 +58,11 @@ async function main() {
         linux: {
             target: ["AppImage", "snap", "deb", "dir"],
             category: "Utility",
-            publish: ["github"],
         },
         snap: {
             confinement: "strict",
             plugs: ["desktop", "home", "browser-support", "network", "opengl", "x11", "wayland", "unity7"],
+            publish: ["github"],
         },
         afterSign: "scripts/notarize.js",
     };

--- a/packages/electron/prepare-build.js
+++ b/packages/electron/prepare-build.js
@@ -58,6 +58,7 @@ async function main() {
         linux: {
             target: ["AppImage", "snap", "deb", "dir"],
             category: "Utility",
+            publish: ["github"],
         },
         snap: {
             confinement: "strict",


### PR DESCRIPTION
This should allow the built snap to be uploaded to the GH release. It was built in https://github.com/padloc/padloc/runs/7500288391?check_suite_focus=true but never published.

The [snap listing is now publicly available](https://snapcraft.io/padloc) and it's in the [latest release](https://github.com/padloc/padloc/releases/latest) with the amd64 version (I'm not sure how to get my hands on an intel version -- @MaKleSoft can you try running `PL_PWA_URL=https://web.padloc.app npm run electron:build` to see if that gives you a linux intel version in macOS? My mac's M1, so that wouldn't work).

This change is made because [`snap`'s default `publish` setting is `snapStore`](https://www.electron.build/configuration/publish.html), which we could do but I don't want to right now. It's not hard to run `snapcraft upload file.snap` and then manage the status from the UI (or CLI as well).