### PR TITLE
Add flag to completely disable multi-factor authentication for a given account

### DIFF
--- a/packages/core/src/auth.ts
+++ b/packages/core/src/auth.ts
@@ -231,6 +231,9 @@ export class Auth extends Serializable implements Storable {
     @AsSerializable(PBES2Container)
     legacyData?: PBES2Container;
 
+    /** Completely disables mfa for a given account. Only use for testing! */
+    disableMFA = false;
+
     constructor(public email: string = "") {
         super();
     }

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -355,7 +355,8 @@ export class Controller extends API {
         auth.authRequests.push(request);
 
         const deviceTrusted =
-            this.context.device && auth.trustedDevices.some(({ id }) => id === this.context.device!.id);
+            auth.disableMFA ||
+            (this.context.device && auth.trustedDevices.some(({ id }) => id === this.context.device!.id));
 
         const response = new StartAuthRequestResponse({
             id: request.id,


### PR DESCRIPTION
We especially need this specifically for apple reviewers, since they sometimes insist on using an existing account and getting the mfa code to them is a pita. Might be useful for other purposes, too. Disabled by default obviously.