### PR TITLE
Fix problem with OrgProvisioning::owner property

### DIFF
--- a/packages/core/src/org.ts
+++ b/packages/core/src/org.ts
@@ -309,17 +309,20 @@ export class Org extends SharedContainer implements Storable {
 
     /** [[Account]] which created this organization */
     get owner() {
-        return this.members.find((member) => member.role === OrgRole.Owner);
+        const owner = this.members.find((member) => member.role === OrgRole.Owner);
+        return owner
+            ? {
+                  accountId: owner.accountId,
+                  email: owner.email,
+              }
+            : undefined;
     }
 
     get info(): OrgInfo {
         return {
             id: this.id,
             name: this.name,
-            owner: this.owner && {
-                email: this.owner.email,
-                accountId: this.owner.accountId,
-            },
+            owner: this.owner,
             revision: this.revision,
         };
     }

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -970,7 +970,7 @@ export class Controller extends API {
             throw new Err(ErrorCode.OUTDATED_REVISION);
         }
 
-        const isOwner = org.owner?.id === account.id || org.isOwner(account);
+        const isOwner = org.owner?.accountId === account.id || org.isOwner(account);
         const isAdmin = isOwner || org.isAdmin(account);
 
         // Only admins can make any changes to organizations at all.


### PR DESCRIPTION
While looking through the database, I noticed that in the `orgprovisioning` table, the `owner` property was stored as a string instead of a json object. Turns out the problem was that [here](https://github.com/padloc/padloc/blob/main/packages/core/src/provisioning.ts#L424) the owner property was set to a reference of the `OrgMember` class instead of a plain object, which caused problems during serialisation. This PR should fix that. 