### PR TITLE
Fix changing master password + UX/UI improvements

### DIFF
--- a/packages/app/src/elements/settings-security.ts
+++ b/packages/app/src/elements/settings-security.ts
@@ -458,9 +458,11 @@ export class SettingsSecurity extends StateMixin(Routing(LitElement)) {
                     <pl-button class="subtle skinny transparent">
                         <pl-icon icon="info-round"></pl-icon>
                     </pl-button>
-                    <pl-popover class="small double-padded max-width-20em"
-                        >${"These are all the sessions for your account that haven't been revoked. They can be logged out or locked, but your email and master password were used to successfully login at one point. If you're not sure a given session should be active, you can simply revoke it."}</pl-popover
-                    >
+                    <pl-popover class="small double-padded max-width-20em">
+                        ${$l(
+                            "Active sessions indicate which devices or browsers are currently logged into your account. Note that sessions are not automatically revoked if you close or uninstall the Padloc app (or close the browser tab if you're using the web app). So it's possible that some devices that you haven't used Padloc on in a while still show up as active sessions. If you're unsure which device a session belongs to, simply revoke it."
+                        )}
+                    </pl-popover>
                 </h2>
                 <pl-list>
                     ${sessions.map((session) => {
@@ -524,9 +526,11 @@ export class SettingsSecurity extends StateMixin(Routing(LitElement)) {
                     <pl-button class="subtle skinny transparent">
                         <pl-icon icon="info-round"></pl-icon>
                     </pl-button>
-                    <pl-popover class="small double-padded max-width-20em"
-                        >${"These are all the devices on which you've logged in where you will not have to go through the email authentication/verification process again (MFA). Even if your session is revoked on these, logging in will only require your email and master password to sign back in. If you've lost access to any of these, make sure to remove them."}</pl-popover
-                    >
+                    <pl-popover class="small double-padded max-width-20em">
+                        ${$l(
+                            "Trusted devices are devices that are excluded from multi-factor authentication, which means that logging in from these devices will only require your email and master password. If you have lost or don't recognise any of these devices, please make sure to remove them."
+                        )}
+                    </pl-popover>
                 </h2>
                 <pl-list>
                     ${trustedDevices.map((device) => {

--- a/packages/app/src/lib/util.ts
+++ b/packages/app/src/lib/util.ts
@@ -22,7 +22,7 @@ export async function formatDateFromNow(date: Date | string | number, addSuffix 
     return formatDistanceToNow(new Date(date), { addSuffix });
 }
 
-export async function formatDate(date: Date | string | number) {
+export function formatDate(date: Date | string | number) {
     return new Intl.DateTimeFormat().format(new Date(date));
 }
 

--- a/packages/core/src/account.ts
+++ b/packages/core/src/account.ts
@@ -132,7 +132,10 @@ export class Account extends PBES2Container implements Storable {
 
     /** Updates the master password by reencrypting the [[privateKey]] and [[signingKey]] properties */
     async setPassword(password: string) {
-        await super.unlock(password);
+        if (!this._key) {
+            throw "Account has to be unlocked first.";
+        }
+        await this._deriveAndSetKey(password);
         await this._commitSecrets();
         this.updated = new Date();
     }

--- a/packages/core/src/account.ts
+++ b/packages/core/src/account.ts
@@ -148,7 +148,7 @@ export class Account extends PBES2Container implements Storable {
 
     /**
      * Unlocks the account by providing the encryption key directly rather than
-     * deriving it fro the master password
+     * deriving it from the master password
      */
     async unlockWithMasterKey(key: Uint8Array) {
         this._key = key;

--- a/packages/core/src/account.ts
+++ b/packages/core/src/account.ts
@@ -132,7 +132,7 @@ export class Account extends PBES2Container implements Storable {
 
     /** Updates the master password by reencrypting the [[privateKey]] and [[signingKey]] properties */
     async setPassword(password: string) {
-        if (!this._key) {
+        if (this.encryptedData && !this._key) {
             throw "Account has to be unlocked first.";
         }
         await this._deriveAndSetKey(password);

--- a/packages/core/src/app.ts
+++ b/packages/core/src/app.ts
@@ -759,10 +759,7 @@ export class App {
         await this.updateAccount(async (account) => {
             // Update account object
             await account.unlock(oldPassword);
-            const data = await account.getData();
-            delete account.encryptedData;
             await account.setPassword(newPassword);
-            await account.setData(data);
 
             // Update auth object
             const auth = new Auth(account.email);

--- a/packages/core/src/app.ts
+++ b/packages/core/src/app.ts
@@ -753,17 +753,21 @@ export class App {
     /**
      * Updates the users master password
      */
-    async changePassword(password: string) {
+    async changePassword(oldPassword: string, newPassword: string) {
         // TODO: Add option to rotate keys
 
         await this.updateAccount(async (account) => {
             // Update account object
-            await account.setPassword(password);
+            await account.unlock(oldPassword);
+            const data = await account.getData();
+            delete account.encryptedData;
+            await account.setPassword(newPassword);
+            await account.setData(data);
 
             // Update auth object
             const auth = new Auth(account.email);
             auth.account = account.id;
-            const authKey = await auth.getAuthKey(password);
+            const authKey = await auth.getAuthKey(newPassword);
             const srp = new SRPClient();
             await srp.initialize(authKey);
             auth.verifier = srp.v!;

--- a/packages/core/src/container.ts
+++ b/packages/core/src/container.ts
@@ -109,14 +109,18 @@ export class PBES2Container extends BaseContainer {
     @AsSerializable(PBKDF2Params)
     keyParams: PBKDF2Params = new PBKDF2Params();
 
-    /**
-     * Unlocks the container using the given **password**
-     */
-    async unlock(password: string) {
+    protected async _deriveAndSetKey(password: string) {
         if (!this.keyParams.salt.length) {
             this.keyParams.salt = await getProvider().randomBytes(16);
         }
         this._key = await getProvider().deriveKey(stringToBytes(password), this.keyParams);
+    }
+
+    /**
+     * Unlocks the container using the given **password**
+     */
+    async unlock(password: string) {
+        await this._deriveAndSetKey(password);
         // If this container has data already, make sure the derived key properly decrypts it.
         if (this.encryptedData) {
             await this.getData();


### PR DESCRIPTION
This fixes changing the master password and adds some UI info for better UX to the device/session list.

Basically the problem was that we were trying to unlock/decrypt the data with the new password, before encrypting it with it (so it was encrypted with the old password still). Now we decrypt with the old password and encrypt with the new one.

I've tested this with shared vaults as well.

Fixes #527
Fixes #516

@MaKleSoft merging against `main` instead of `v4.1.0` because it seems like this is something worthy of `v4.0.2`.