### PR TITLE
Make release assets consistent

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -82,7 +82,7 @@ jobs:
                   repo_token: ${{ secrets.GITHUB_TOKEN }}
                   tag: "v${{ env.PL_VENDOR_VERSION }}"
                   file: packages/extension/dist/web-ext-artifacts/padloc-${{ env.PL_VENDOR_VERSION }}.${{ env.RELEASE_BUILD }}.xpi
-                  asset_name: padloc-web-extension-${{ env.PL_VENDOR_VERSION }}.${{ env.RELEASE_BUILD }}.xpi
+                  asset_name: padloc_${{ env.PL_VENDOR_VERSION }}_web-extension_firefox.xpi
                   prerelease: true
             - name: Pack for Chrome/Edge Extension
               uses: cardinalby/webext-buildtools-pack-extension-dir-action@v1
@@ -96,7 +96,7 @@ jobs:
                   repo_token: ${{ secrets.GITHUB_TOKEN }}
                   tag: "v${{ env.PL_VENDOR_VERSION }}"
                   file: packages/extension/padloc.zip
-                  asset_name: padloc-web-extension-${{ env.PL_VENDOR_VERSION }}.${{ env.RELEASE_BUILD }}-unsigned.zip
+                  asset_name: padloc_${{ env.PL_VENDOR_VERSION }}_web-extension_unsigned.zip
                   prerelease: true
             - name: Sign for Chrome/Edge
               uses: cardinalby/webext-buildtools-chrome-crx-action@v2
@@ -110,7 +110,7 @@ jobs:
                   repo_token: ${{ secrets.GITHUB_TOKEN }}
                   tag: "v${{ env.PL_VENDOR_VERSION }}"
                   file: packages/extension/padloc-signed.crx
-                  asset_name: padloc-web-extension-${{ env.PL_VENDOR_VERSION }}.${{ env.RELEASE_BUILD }}.crx
+                  asset_name: padloc_${{ env.PL_VENDOR_VERSION }}_web-extension_chrome.crx
                   prerelease: true
             - name: Generate checksum (xpi)
               run: |
@@ -491,7 +491,7 @@ jobs:
                   repo_token: ${{ secrets.GITHUB_TOKEN }}
                   tag: "v${{ env.PL_VENDOR_VERSION }}"
                   file: packages/cordova/platforms/android/app/build/outputs/apk/release/app-release.apk
-                  asset_name: padloc-${{ env.PL_VENDOR_VERSION }}.apk
+                  asset_name: padloc_${{ env.PL_VENDOR_VERSION }}_android.apk
                   prerelease: true
             - name: Upload Signed IPA
               if: matrix.platform == 'macos-latest'
@@ -500,7 +500,7 @@ jobs:
                   repo_token: ${{ secrets.GITHUB_TOKEN }}
                   tag: "v${{ env.PL_VENDOR_VERSION }}"
                   file: packages/cordova/platforms/ios/build/device/Padloc.ipa
-                  asset_name: padloc-${{ env.PL_VENDOR_VERSION }}.ipa
+                  asset_name: padloc_${{ env.PL_VENDOR_VERSION }}_ios.ipa
                   prerelease: true
             - name: Generate checksum (apk)
               if: matrix.platform == 'ubuntu-latest'
@@ -573,7 +573,7 @@ jobs:
                   repo_token: ${{ secrets.GITHUB_TOKEN }}
                   tag: "v${{ env.PL_VENDOR_VERSION }}"
                   file: packages/pwa/pwa.tar.gz
-                  asset_name: padloc-pwa-${{ env.PL_VENDOR_VERSION }}.${{ env.RELEASE_BUILD }}.tar.gz
+                  asset_name: padloc_${{ env.PL_VENDOR_VERSION }}_pwa.tar.gz
                   prerelease: true
             - name: Generate checksums
               run: |

--- a/packages/electron/prepare-build.js
+++ b/packages/electron/prepare-build.js
@@ -33,13 +33,13 @@ async function main() {
     const buildConfig = {
         appId,
         buildVersion,
-        artifactName: "${name}_${version}_${os}_electron_${arch}.${ext}",
+        artifactName: `${name.toLowerCase()}_\${version}_\${os}_electron_\${arch}.\${ext}`,
         directories: {
             app: "app",
             buildResources: "build",
         },
         mac: {
-            artifactName: "${name}_${version}_macos_electron_${arch}.${ext}",
+            artifactName: `${name.toLowerCase()}_\${version}_macos_electron_\${arch}.\${ext}`,
             hardenedRuntime: true,
             darkModeSupport: true,
             gatekeeperAssess: false,
@@ -67,7 +67,7 @@ async function main() {
             publish: ["github"],
         },
         win: {
-            artifactName: "${name}_${version}_windows_electron_${arch}.${ext}",
+            artifactName: `${name.toLowerCase()}_\${version}_windows_electron_\${arch}.\${ext}`,
         },
         afterSign: "scripts/notarize.js",
     };

--- a/packages/electron/prepare-build.js
+++ b/packages/electron/prepare-build.js
@@ -33,11 +33,13 @@ async function main() {
     const buildConfig = {
         appId,
         buildVersion,
+        artifactName: "${name}_${version}_${os}_electron_${arch}.${ext}",
         directories: {
             app: "app",
             buildResources: "build",
         },
         mac: {
+            artifactName: "${name}_${version}_macos_electron_${arch}.${ext}",
             hardenedRuntime: true,
             darkModeSupport: true,
             gatekeeperAssess: false,
@@ -63,6 +65,9 @@ async function main() {
             confinement: "strict",
             plugs: ["desktop", "home", "browser-support", "network", "opengl", "x11", "wayland", "unity7"],
             publish: ["github"],
+        },
+        win: {
+            artifactName: "${name}_${version}_windows_electron_${arch}.${ext}",
         },
         afterSign: "scripts/notarize.js",
     };


### PR DESCRIPTION
Unfortunately [it's not yet possible for Tauri](https://github.com/tauri-apps/tauri-action/issues/215), nor there's any GH action for that, _but_ [there's an API endpoint](https://docs.github.com/en/rest/releases/assets#update-a-release-asset) we could use.

Since it's only the Tauri assets that are not according to the new standard, I think it's fine to keep it something we manually update, otherwise we can try to build a script that taps into that endpoint, later.