### PR TITLE
Generate better device descriptions for Tauri runtime

### DIFF
--- a/packages/tauri/src/platform.ts
+++ b/packages/tauri/src/platform.ts
@@ -5,6 +5,7 @@ export class TauriPlatform extends WebPlatform implements Platform {
     async getDeviceInfo() {
         const device = await super.getDeviceInfo();
         device.runtime = "tauri";
+        device.description = `${device.platform} Device`;
         return device;
     }
 }


### PR DESCRIPTION
Fixes https://github.com/padloc/padloc/issues/517

Unfortunately we can't do better that "Windows Device", "MacOS Device" etc. right now because we don't have access to the computer name yet. Specifically having an equivalent of Nodes `os.hostname` would be helpful, which is planned but not ready yet. See https://github.com/tauri-apps/tauri/issues/2233