### PR TITLE
Fix typos in `_template.json`

### DIFF
--- a/packages/locale/res/translations/_template.json
+++ b/packages/locale/res/translations/_template.json
@@ -592,7 +592,7 @@
     ""
   ],
   [
-    "{0} was successfully added to your organisation!",
+    "{0} was successfully added to your organization!",
     ""
   ],
   [
@@ -1012,7 +1012,7 @@
     ""
   ],
   [
-    "Are you sure you want to transfer this organizations ownership to {0}?",
+    "Are you sure you want to transfer this organization's ownership to {0}?",
     ""
   ],
   [
@@ -1252,7 +1252,7 @@
     ""
   ],
   [
-    "Do you want to rotate this organizations cryptographic keys? All organization memberships will have to be reconfirmed but no data will be lost.",
+    "Do you want to rotate this organization's cryptographic keys? All organization memberships will have to be reconfirmed but no data will be lost.",
     ""
   ],
   [
@@ -1260,7 +1260,7 @@
     ""
   ],
   [
-    "The organizations cryptographic keys have been rotated successfully and membership confirmation requests for all members have been sent out.",
+    "This organization's cryptographic keys have been rotated successfully and membership confirmation requests for all members have been sent out.",
     ""
   ],
   [
@@ -1492,7 +1492,7 @@
     ""
   ],
   [
-    "If this option is enabled, masked fields such as passwords or credit card numbers will be unmasked when you move your mouse over them.Disable this option if you would rather use an explicit button.",
+    "If this option is enabled, masked fields such as passwords or credit card numbers will be unmasked when you move your mouse over them. Disable this option if you would rather use an explicit button.",
     ""
   ],
   [
@@ -1844,7 +1844,7 @@
     ""
   ],
   [
-    "Please assign at least on member or group to this vault!",
+    "Please assign at least one member or group to this vault!",
     ""
   ],
   [
@@ -1968,7 +1968,7 @@
     ""
   ],
   [
-    "Some data associated with your account was saved with a newer version of Padloc and cannot be decoded. Please install the latest version Padloc!",
+    "Some data associated with your account was saved with a newer version of Padloc and cannot be decoded. Please install the latest version of Padloc!",
     ""
   ],
   [
@@ -2000,15 +2000,15 @@
     ""
   ],
   [
-    "Local changes to this vault could not be synchronized because there was a problem retrieving information for this vaults organization. If this problem persists please contact customer support!",
+    "Local changes to this vault could not be synchronized because there was a problem retrieving information for this vault's organization. If this problem persists please contact customer support!",
     ""
   ],
   [
-    "Synching local changes failed because the organization this vault belongs to is frozen.",
+    "Syncing local changes failed because the organization this vault belongs to is frozen.",
     ""
   ],
   [
-    "Synching local changes failed because you don't have write permissions for this vault.",
+    "Syncing local changes failed because you don't have write permissions for this vault.",
     ""
   ],
   [


### PR DESCRIPTION
- `organisation` > `organization` to keep consistency
- Possessive apostrophe
- `synching` > `syncing` as the latter is more commonly used
- Other little fixes