### PR TITLE
Basic Audit Logs

### DIFF
--- a/docs/examples/config/example.env
+++ b/docs/examples/config/example.env
@@ -153,7 +153,7 @@
 # =============================================================================
 # LOGGING
 #
-# Supported backends: void (default), mongodb, mixpanel
+# Supported backends: void (default), mongodb, mixpanel, postgres
 # =============================================================================
 
 # -----------------------------------------------------------------------------
@@ -209,6 +209,57 @@
 # PL_LOGGING_BACKEND=mixpanel
 # PL_LOGGING_MIXPANEL_TOKEN=[required]
 # PL_LOGGING_MIXPANEL_EXCLUDE_EVENTS=""
+
+
+# =============================================================================
+# AUDITOR
+#
+# Supported backends: void (default), mongodb, postgres
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# VOID
+#
+# Don't log at all
+# -----------------------------------------------------------------------------
+
+# PL_AUDITOR_BACKEND=void
+
+# -----------------------------------------------------------------------------
+# MONGODB
+#
+# Use mongodb for log storage
+# -----------------------------------------------------------------------------
+
+# PL_AUDITOR_BACKEND=mongodb
+# PL_AUDITOR_MONGODB_HOST=localhost
+# PL_AUDITOR_MONGODB_PORT=27017
+# PL_AUDITOR_MONGODB_PROTOCOL=mongodb
+# PL_AUDITOR_MONGODB_USERNAME=""
+# PL_AUDITOR_MONGODB_PASSWORD=""
+# PL_AUDITOR_MONGODB_DATABASE=padloc_audit
+# PL_AUDITOR_MONGODB_AUTH_DATABASE=""
+# PL_AUDITOR_MONGODB_TLS=false
+# PL_AUDITOR_MONGODB_TLS_CAFILE=""
+# PL_AUDITOR_MONGODB_ACKNOWLEDGE_WRITES=true
+# PL_AUDITOR_MONGODB_MAX_SIZE=""
+# PL_AUDITOR_MONGODB_MAX_DOCUMENTS=""
+
+# -----------------------------------------------------------------------------
+# POSTGRES
+#
+# Use postgresql as log storage: https://www.npmjs.com/package/pg
+# -----------------------------------------------------------------------------
+
+# PL_AUDITOR_BACKEND=postgres
+# PL_AUDITOR_POSTGRES_HOST=localhost
+# PL_AUDITOR_POSTGRES_PORT=5432
+# PL_AUDITOR_POSTGRES_DATABASE=padloc_audit
+# PL_AUDITOR_POSTGRES_USER=padloc
+# PL_AUDITOR_POSTGRES_PASSWORD=""
+# PL_AUDITOR_POSTGRES_TLS=false
+# PL_AUDITOR_POSTGRES_TLS_CAFILE=""
+# PL_AUDITOR_POSTGRES_TLS_REJECT_UNAUTHORIZED=true
 
 
 # =============================================================================

--- a/packages/app/src/elements/item-icon.ts
+++ b/packages/app/src/elements/item-icon.ts
@@ -48,7 +48,10 @@ export class ItemIcon extends LitElement {
             } catch (e) {}
         }
 
-        const favIcon = app.settings.favicons && url ? `https://icons.duckduckgo.com/ip3/${url}.ico` : undefined;
+        const faviconUrl = url?.startsWith("*.") ? url.replace("*.", "") : url;
+
+        const favIcon =
+            app.settings.favicons && faviconUrl ? `https://icons.duckduckgo.com/ip3/${faviconUrl}.ico` : undefined;
 
         // const dataUrl = favIcon && (await this._loadAsDataUrl(favIcon));
         // console.log(dataUrl);

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -400,15 +400,11 @@ export class ItemAuditorLogParams extends Serializable {
         Object.assign(this, vals);
     }
 
-    itemId: string = "";
+    itemId?: string;
 
-    auditChangeType: AuditChangeType = "created";
+    auditChangeType?: AuditChangeType;
 
-    @AsBytes()
-    oldData: Uint8Array | null = null;
-
-    @AsBytes()
-    newData: Uint8Array | null = null;
+    metadata?: any;
 }
 
 interface HandlerDefinition {
@@ -731,6 +727,7 @@ export class API {
      * Auditor log for an item
      *
      * @authentiation_required
+     *
      */
     @Handler(ItemAuditorLogParams, undefined)
     itemAuditorLog(_params: ItemAuditorLogParams): PromiseWithProgress<void> {

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -12,6 +12,7 @@ import { AuthPurpose, AuthType, AuthenticatorInfo, Auth, AccountStatus, AuthRequ
 import { KeyStoreEntry, KeyStoreEntryInfo } from "./key-store";
 import { DeviceInfo } from "./platform";
 import { Provisioning, AccountProvisioning } from "./provisioning";
+import { AuditChangeType } from "./auditor";
 
 /**
  * Api parameters for creating a new Account to be used with [[API.createAccount]].
@@ -393,6 +394,23 @@ export class UpdateAuthParams extends Serializable {
     mfaOrder?: string[] = undefined;
 }
 
+export class ItemAuditorLogParams extends Serializable {
+    constructor(vals: Partial<ItemAuditorLogParams> = {}) {
+        super();
+        Object.assign(this, vals);
+    }
+
+    itemId: string = "";
+
+    auditChangeType: AuditChangeType = "created";
+
+    @AsBytes()
+    oldData: Uint8Array | null = null;
+
+    @AsBytes()
+    newData: Uint8Array | null = null;
+}
+
 interface HandlerDefinition {
     method: string;
     input?: SerializableConstructor;
@@ -706,6 +724,16 @@ export class API {
 
     @Handler(String, undefined)
     removeTrustedDevice(_id: string): PromiseWithProgress<void> {
+        throw "Not implemented";
+    }
+
+    /**
+     * Auditor log for an item
+     *
+     * @authentiation_required
+     */
+    @Handler(ItemAuditorLogParams, undefined)
+    itemAuditorLog(_params: ItemAuditorLogParams): PromiseWithProgress<void> {
         throw "Not implemented";
     }
 }

--- a/packages/core/src/auditor.ts
+++ b/packages/core/src/auditor.ts
@@ -1,0 +1,42 @@
+import { Storable } from "./storage";
+
+export type AuditKind = "auth" | "account" | "org" | "vault" | "item";
+export type AuditChangeType = "created" | "updated" | "deleted";
+
+export class LogChange extends Storable {
+    id: string = "";
+
+    date: Date = new Date();
+
+    get kind(): string {
+        return `audit_log_${this.objectKind}`;
+    }
+
+    constructor(
+        public objectKind: AuditKind,
+        public objectId: string,
+        public modifierAccountId: string,
+        public type: AuditChangeType,
+        public oldData: any,
+        public newData: any
+    ) {
+        super();
+    }
+}
+
+export interface Auditor {
+    log(
+        kind: AuditKind,
+        id: string,
+        modifierAccountId: string,
+        type: AuditChangeType,
+        oldData: any,
+        newData: any
+    ): LogChange;
+}
+
+export class VoidAuditor implements Auditor {
+    log(kind: AuditKind, id: string, modifierAccountId: string, type: AuditChangeType, oldData: any, newData: any) {
+        return new LogChange(kind, id, modifierAccountId, type, oldData, newData);
+    }
+}

--- a/packages/core/src/auditor.ts
+++ b/packages/core/src/auditor.ts
@@ -17,26 +17,18 @@ export class LogChange extends Storable {
         public objectId: string,
         public modifierAccountId: string,
         public type: AuditChangeType,
-        public oldData: any,
-        public newData: any
+        public metadata?: any
     ) {
         super();
     }
 }
 
 export interface Auditor {
-    log(
-        kind: AuditKind,
-        id: string,
-        modifierAccountId: string,
-        type: AuditChangeType,
-        oldData: any,
-        newData: any
-    ): LogChange;
+    log(kind: AuditKind, id: string, modifierAccountId: string, type: AuditChangeType, metadata?: any): LogChange;
 }
 
 export class VoidAuditor implements Auditor {
-    log(kind: AuditKind, id: string, modifierAccountId: string, type: AuditChangeType, oldData: any, newData: any) {
-        return new LogChange(kind, id, modifierAccountId, type, oldData, newData);
+    log(kind: AuditKind, id: string, modifierAccountId: string, type: AuditChangeType, metadata?: any) {
+        return new LogChange(kind, id, modifierAccountId, type, metadata);
     }
 }

--- a/packages/core/src/directory.ts
+++ b/packages/core/src/directory.ts
@@ -57,7 +57,7 @@ export class DirectorySync implements DirectorySubscriber {
 
             org.members.push(newOrgMember);
 
-            await this.server.updateMetaData(org);
+            await this.server.updateMetaData(org, "directory-sync");
             await this.server.storage.save(org);
         }
     }
@@ -89,7 +89,7 @@ export class DirectorySync implements DirectorySubscriber {
 
             existingMember.updated = new Date();
 
-            await this.server.updateMetaData(org);
+            await this.server.updateMetaData(org, "directory-sync");
             await this.server.storage.save(org);
         }
     }
@@ -119,7 +119,7 @@ export class DirectorySync implements DirectorySubscriber {
                 }
             }
 
-            await this.server.updateMetaData(org);
+            await this.server.updateMetaData(org, "directory-sync");
             await this.server.storage.save(org);
         }
     }
@@ -149,7 +149,7 @@ export class DirectorySync implements DirectorySubscriber {
 
             org.groups.push(newGroup);
 
-            await this.server.updateMetaData(org);
+            await this.server.updateMetaData(org, "directory-sync");
             await this.server.storage.save(org);
         }
     }
@@ -180,7 +180,7 @@ export class DirectorySync implements DirectorySubscriber {
 
             existingGroup.members = members;
 
-            await this.server.updateMetaData(org);
+            await this.server.updateMetaData(org, "directory-sync");
             await this.server.storage.save(org);
         }
     }
@@ -194,7 +194,7 @@ export class DirectorySync implements DirectorySubscriber {
             }
             org.groups.splice(existingGroupIndex, 1);
 
-            await this.server.updateMetaData(org);
+            await this.server.updateMetaData(org, "directory-sync");
             await this.server.storage.save(org);
         }
     }

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -22,6 +22,7 @@ import {
     GetKeyStoreEntryParams,
     AuthInfo,
     UpdateAuthParams,
+    ItemAuditorLogParams,
 } from "./api";
 import { Storage } from "./storage";
 import { Attachment, AttachmentStorage } from "./attachment";
@@ -1003,8 +1004,6 @@ export class Controller extends API {
 
         this.auditor.log("vault", account.mainVault.id, account.id, "deleted", account.mainVault, null);
 
-        // TODO: Parse and log updates for vault items
-
         // Revoke all sessions
         await auth.sessions.map((s) => this.storage.delete(Object.assign(new Session(), s)));
 
@@ -1397,8 +1396,6 @@ export class Controller extends API {
                 const vault = Object.assign(new Vault(), v);
                 this.storage.delete(vault);
                 this.auditor.log("vault", vault.id, account.id, "deleted", vault, null);
-
-                // TODO: Parse and log updates for vault items
             })
         );
 
@@ -1513,8 +1510,6 @@ export class Controller extends API {
         await this.storage.save(vault);
 
         this.auditor.log("vault", vault.id, account.id, "updated", originalVault, vault);
-
-        // TODO: Parse and log updates for vault items
 
         if (org) {
             // Update Org revision (since vault info has changed)
@@ -1641,8 +1636,6 @@ export class Controller extends API {
         });
 
         this.auditor.log("vault", vault.id, account.id, "deleted", vault, null);
-
-        // TODO: Parse and log updates for vault items
     }
 
     async getInvite({ org: orgId, id }: GetInviteParams) {
@@ -1930,6 +1923,12 @@ export class Controller extends API {
         this.log("account.deleteKeyStoreEntry", {
             keyStoreEntry: { id: entry.id },
         });
+    }
+
+    async itemAuditorLog({ itemId, auditChangeType, oldData, newData }: ItemAuditorLogParams): Promise<void> {
+        const { account } = this._requireAuth();
+
+        this.auditor.log("item", itemId, account.id, auditChangeType, oldData, newData);
     }
 
     private _requireAuth(): { account: Account; session: Session; auth: Auth; provisioning: Provisioning } {

--- a/packages/core/src/util.ts
+++ b/packages/core/src/util.ts
@@ -244,6 +244,22 @@ export function setPath(obj: any, path: string, value: any) {
     }
 }
 
-export function deepClone(object: any) {
+// Simple (as in a plain object), not shallow
+export function simpleClone(object: any) {
     return JSON.parse(JSON.stringify(object));
+}
+
+// Copies everything recursively, including class, getters and setters
+export function deepClone(object: any) {
+    if (object === null || typeof object !== "object") {
+        return object;
+    }
+
+    const properties = Object.getOwnPropertyDescriptors(object);
+
+    for (const property in properties) {
+        properties[property].value = deepClone(properties[property].value);
+    }
+
+    return Object.create(Object.getPrototypeOf(object), properties);
 }

--- a/packages/core/src/util.ts
+++ b/packages/core/src/util.ts
@@ -243,3 +243,7 @@ export function setPath(obj: any, path: string, value: any) {
         obj[path] = value;
     }
 }
+
+export function deepClone(object: any) {
+    return JSON.parse(JSON.stringify(object));
+}

--- a/packages/server/src/auditor/mongodb.ts
+++ b/packages/server/src/auditor/mongodb.ts
@@ -5,8 +5,8 @@ import { MongoDBStorage } from "../storage/mongodb";
 export class MongoDBAuditor implements Auditor {
     constructor(private _storage: MongoDBStorage) {}
 
-    log(kind: AuditKind, id: string, modifierAccountId: string, type: AuditChangeType, oldData: any, newData: any) {
-        const auditLog = new LogChange(kind, id, modifierAccountId, type, oldData, newData);
+    log(kind: AuditKind, id: string, modifierAccountId: string, type: AuditChangeType, metadata?: any) {
+        const auditLog = new LogChange(kind, id, modifierAccountId, type, metadata);
         auditLog.id = new ObjectId().toString();
         (async () => {
             try {

--- a/packages/server/src/auditor/mongodb.ts
+++ b/packages/server/src/auditor/mongodb.ts
@@ -1,0 +1,18 @@
+import { Auditor, LogChange, AuditKind, AuditChangeType } from "@padloc/core/src/auditor";
+import { ObjectId } from "mongodb";
+import { MongoDBStorage } from "../storage/mongodb";
+
+export class MongoDBAuditor implements Auditor {
+    constructor(private _storage: MongoDBStorage) {}
+
+    log(kind: AuditKind, id: string, modifierAccountId: string, type: AuditChangeType, oldData: any, newData: any) {
+        const auditLog = new LogChange(kind, id, modifierAccountId, type, oldData, newData);
+        auditLog.id = new ObjectId().toString();
+        (async () => {
+            try {
+                this._storage.save(auditLog, { useObjectId: true, acknowledge: false });
+            } catch (e) {}
+        })();
+        return auditLog;
+    }
+}

--- a/packages/server/src/auditor/postgres.ts
+++ b/packages/server/src/auditor/postgres.ts
@@ -1,0 +1,17 @@
+import { Auditor, LogChange, AuditKind, AuditChangeType } from "@padloc/core/src/auditor";
+import { PostgresStorage } from "../storage/postgres";
+
+export class PostgresAuditor implements Auditor {
+    constructor(private _storage: PostgresStorage) {}
+
+    log(kind: AuditKind, id: string, modifierAccountId: string, type: AuditChangeType, oldData: any, newData: any) {
+        const auditLog = new LogChange(kind, id, modifierAccountId, type, oldData, newData);
+        auditLog.id = `${auditLog.time.toISOString()}_${Math.floor(Math.random() * 1e6)}`;
+        (async () => {
+            try {
+                this._storage.save(auditLog);
+            } catch (e) {}
+        })();
+        return auditLog;
+    }
+}

--- a/packages/server/src/auditor/postgres.ts
+++ b/packages/server/src/auditor/postgres.ts
@@ -6,7 +6,7 @@ export class PostgresAuditor implements Auditor {
 
     log(kind: AuditKind, id: string, modifierAccountId: string, type: AuditChangeType, oldData: any, newData: any) {
         const auditLog = new LogChange(kind, id, modifierAccountId, type, oldData, newData);
-        auditLog.id = `${auditLog.time.toISOString()}_${Math.floor(Math.random() * 1e6)}`;
+        auditLog.id = `${auditLog.date.toISOString()}_${Math.floor(Math.random() * 1e6)}`;
         (async () => {
             try {
                 this._storage.save(auditLog);

--- a/packages/server/src/auditor/postgres.ts
+++ b/packages/server/src/auditor/postgres.ts
@@ -4,8 +4,8 @@ import { PostgresStorage } from "../storage/postgres";
 export class PostgresAuditor implements Auditor {
     constructor(private _storage: PostgresStorage) {}
 
-    log(kind: AuditKind, id: string, modifierAccountId: string, type: AuditChangeType, oldData: any, newData: any) {
-        const auditLog = new LogChange(kind, id, modifierAccountId, type, oldData, newData);
+    log(kind: AuditKind, id: string, modifierAccountId: string, type: AuditChangeType, metadata?: any) {
+        const auditLog = new LogChange(kind, id, modifierAccountId, type, metadata);
         auditLog.id = `${auditLog.date.toISOString()}_${Math.floor(Math.random() * 1e6)}`;
         (async () => {
             try {

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -97,6 +97,22 @@ export class LoggingConfig extends Config {
     mixpanel?: MixpanelConfig;
 }
 
+export class AuditorConfig extends Config {
+    constructor(init: Partial<AuditorConfig> = {}) {
+        super();
+        Object.assign(this, init);
+    }
+
+    @ConfigParam()
+    backend: "void" | "mongodb" | "postgres" = "void";
+
+    @ConfigParam(MongoDBStorageConfig)
+    mongodb?: MongoDBStorageConfig;
+
+    @ConfigParam(PostgresConfig)
+    postgres?: PostgresConfig;
+}
+
 export class AuthConfig extends Config {
     @ConfigParam("string[]")
     types: AuthType[] = [AuthType.Email, AuthType.Totp];
@@ -159,6 +175,9 @@ export class PadlocConfig extends Config {
 
     @ConfigParam(LoggingConfig)
     logging = new LoggingConfig();
+
+    @ConfigParam(AuditorConfig)
+    auditor = new AuditorConfig();
 
     @ConfigParam(AuthConfig)
     auth = new AuthConfig();


### PR DESCRIPTION
Initial setup and work, a few questions still need answering, and only working for some auth-related actions right now.

This is a very rough note on some things I wanted to achieve/remember/attempt with this:

- separate database and potentially database connection, logs table
    - table/audit log per data type:
      - auth
        - auth_id
        - modifier_account_id
        - date
        - type (created, updated, deleted)
        - old_data (encrypted)
        - new_data (encrypted)
        - (account_id can be found via old_data -> account_id or new_data -> account_id)
      - account
        - account_id
        - modifier_account_id
        - date
        - type (created, updated, deleted)
        - old_data (encrypted)
        - new_data (encrypted)
        - (auth_id can be found via old_data -> auth_id or new_data -> auth_id)
      - org
        - org_id
        - modifier_account_id
        - date
        - type (created, updated, deleted)
        - old_data (encrypted)
        - new_data (encrypted)
        - (auth_id or account_id can be found via old_data -> account_id or new_data -> account_id)
      - vault
        - vault_id
        - modifier_account_id
        - date
        - type (created, updated, deleted)
        - old_data (encrypted)
        - new_data (encrypted)
        - (org_id or account_id can be found via old_data -> account_id or new_data -> account_id)
      - item
        - item_id
        - modifier_account_id
        - date
        - type (created, updated, deleted)
        - old_data (encrypted)
        - new_data (encrypted)
        - (vault_id or org_id or account_id can be found via old_data -> account_id or new_data -> account_id)
- [x] store when changes happen
- [x] new class: auditor, new Auditor, server.auditor.log(kind, id, modifier_account_id, date, type, old_data, new_data)
- [x] when a password changes, decrypt and encrypt all audit logs for that account

This is related to #433 but in order to close that, we'll need a way to display these logs, which I'd prefer to do in a separate PR, but would be amenable to implementing it here too.