### PR TITLE
Implement Bitwarden Import

### DIFF
--- a/packages/app/src/elements/import-dialog.ts
+++ b/packages/app/src/elements/import-dialog.ts
@@ -309,6 +309,9 @@ export class ImportDialog extends Dialog<File, void> {
             case imp.ONEPUX.value:
                 this._items = await imp.as1Pux(file);
                 break;
+            case imp.BITWARDEN.value:
+                this._items = await imp.asBitwarden(file);
+                break;
             case imp.PBES2.value:
                 this.open = false;
                 const pwd2 = await prompt($l("This file is protected by a password."), {

--- a/packages/app/src/elements/settings-tools.ts
+++ b/packages/app/src/elements/settings-tools.ts
@@ -71,7 +71,7 @@ export class SettingsTools extends StateMixin(LitElement) {
 
             <input
                 type="file"
-                accept="text/plain,.csv,.pls,.set,.pbes2,.1pux"
+                accept="text/plain,.csv,.pls,.set,.pbes2,.1pux,.json"
                 hidden
                 @change=${() => this._importFile()}
             />

--- a/packages/app/src/lib/audit.ts
+++ b/packages/app/src/lib/audit.ts
@@ -251,7 +251,7 @@ export function noItemsTextForAudit(type: AuditType) {
         case AuditType.CompromisedPassword:
             return $l("You don't have any items with compromised passwords!");
         case AuditType.ExpiredItem:
-            return $l("You don't have any expiring or expired items!");
+            return $l("You don't have any expired items!");
         default:
             return $l("You don't have any insecure items!");
     }
@@ -303,7 +303,7 @@ export function descriptionForAudit(type: AuditType) {
             );
         case AuditType.ExpiredItem:
             return $l(
-                "Expiring or expired items are those that have been identified as being close to or past their set expiry date, which haven't been updated in a manually set number of days. These items should be rotated as soon as possible."
+                "Expired items are those that have been identified as being past their set expiry date, which haven't been updated in a given number of days. These items should be rotated as soon as possible."
             );
         default:
             "";

--- a/packages/app/src/lib/bitwarden-parser.ts
+++ b/packages/app/src/lib/bitwarden-parser.ts
@@ -1,0 +1,220 @@
+import { translate as $l } from "@padloc/locale/src/translate";
+
+export enum BitwardenItemFieldType {
+    Text = 0,
+    Hidden = 1,
+    Boolean = 2,
+    Linked = 3,
+}
+
+export type BitwardenItemField = {
+    name: string;
+    value: string;
+    type: BitwardenItemFieldType;
+};
+
+export type BitwardenItemLoginUri = {
+    match?: string;
+    uri: string;
+};
+
+export type BitwardenFolder = {
+    id: string;
+    name: string;
+};
+
+export enum BitwardenItemType {
+    Login = 1,
+    SecureNote = 2,
+    Card = 3,
+    Identity = 4,
+}
+
+export enum BitwardenItemRepromptType {
+    None = 0,
+    Password = 1,
+}
+
+export enum BitwardenItemSecureNoteType {
+    Generic = 0,
+}
+
+export type BitwardenItem = {
+    id: string;
+    organizationId?: string;
+    folderId?: string;
+    type: BitwardenItemType;
+    reprompt?: BitwardenItemRepromptType;
+    name: string;
+    notes: string;
+    favorite: boolean;
+    fields?: BitwardenItemField[];
+    login?: {
+        uris?: BitwardenItemLoginUri[];
+        username?: string;
+        password?: string;
+        totp?: string;
+    };
+    secureNote?: {
+        type?: BitwardenItemSecureNoteType;
+    };
+    card?: {
+        cardholderName?: string;
+        brand?: string;
+        number?: string;
+        expMonth?: string;
+        expYear?: string;
+        code?: string;
+    };
+    identity?: {
+        title?: string;
+        firstName?: string;
+        middleName?: string;
+        lastName?: string;
+        address1?: string;
+        address2?: string;
+        address3?: string;
+        city?: string;
+        state?: string;
+        postalCode?: string;
+        country?: string;
+        company?: string;
+        email?: string;
+        phone?: string;
+        ssn?: string;
+        username?: string;
+        passportNumber?: string;
+        licenseNumber?: string;
+    };
+    collectionIds?: (string | null)[];
+};
+
+export type BitwardenExport = {
+    folders?: BitwardenFolder[];
+    items: BitwardenItem[];
+};
+
+export async function parseBitwardenFile(dataContent: string): Promise<BitwardenExport> {
+    try {
+        const data = JSON.parse(dataContent);
+
+        return data as BitwardenExport;
+    } catch (error) {
+        console.error("Failed to parse Bitwarden .json file");
+        throw error;
+    }
+}
+
+type RowData = {
+    name: string;
+    tags: string;
+    url: string;
+    username: string;
+    password: string;
+    notes: string;
+    extraFields: ExtraField[];
+};
+
+type ExtraFieldType =
+    | "username"
+    | "password"
+    | "url"
+    | "email"
+    | "date"
+    | "month"
+    | "credit"
+    | "phone"
+    | "totp"
+    | "text"
+    | "pin";
+
+type ExtraField = { name: string; value: string; type: ExtraFieldType };
+
+function parseFieldTypeToExtraFieldType(field: BitwardenItemField): ExtraFieldType {
+    if (field.type === BitwardenItemFieldType.Linked) {
+        return "url";
+    } else if (field.type === BitwardenItemFieldType.Hidden) {
+        return "password";
+    }
+
+    return "text";
+}
+
+export function parseToRowData(
+    item: BitwardenItem,
+    defaultTags?: string[],
+    folders?: BitwardenFolder[]
+): RowData | undefined {
+    if (!item) {
+        return;
+    }
+
+    const folderName = item.folderId ? folders?.find((folder) => folder.id === item.folderId)?.name : "";
+
+    const rowData: RowData = {
+        name: item.name,
+        tags: [...(defaultTags || []), ...(folderName ? [folderName] : [])].join(","),
+        url: item.login?.uris ? item.login?.uris[0].uri : "",
+        username: item.login?.username || "",
+        password: item.login?.password || "",
+        notes: item.notes || "",
+        extraFields: [],
+    };
+
+    // Extract card into extraFields
+    if (item.type === BitwardenItemType.Card && item.card) {
+        if (item.card.number) {
+            rowData.extraFields.push({
+                name: $l("Card Number"),
+                type: "credit",
+                value: item.card.number,
+            });
+        }
+
+        if (item.card.cardholderName) {
+            rowData.extraFields.push({
+                name: $l("Card Owner"),
+                type: "text",
+                value: item.card.cardholderName,
+            });
+        }
+
+        if (item.card.expYear) {
+            rowData.extraFields.push({
+                name: $l("Valid Until"),
+                type: "month",
+                value: `${item.card.expYear}-${item.card?.expMonth || "01"}`,
+            });
+        }
+
+        if (item.card.code) {
+            rowData.extraFields.push({
+                name: $l("CVC"),
+                type: "pin",
+                value: item.card.code,
+            });
+        }
+    }
+
+    // Extract identity into extraFields
+    if (item.type === BitwardenItemType.Identity && item.identity) {
+        Object.keys(item.identity).forEach((identityField) => {
+            rowData.extraFields.push({
+                name: identityField,
+                type: "text",
+                value: item.identity![identityField],
+            });
+        });
+    }
+
+    // Extract some more extraFields
+    (item.fields || []).forEach((field) => {
+        rowData.extraFields.push({
+            name: field.name,
+            value: field.value,
+            type: parseFieldTypeToExtraFieldType(field),
+        });
+    });
+
+    return rowData;
+}

--- a/packages/app/src/lib/import.ts
+++ b/packages/app/src/lib/import.ts
@@ -8,9 +8,10 @@ import { translate as $l } from "@padloc/locale/src/translate";
 import { readFileAsText, readFileAsArrayBuffer } from "@padloc/core/src/attachment";
 
 import { OnePuxItem } from "./1pux-parser";
+import { BitwardenExport, BitwardenItem } from "./bitwarden-parser";
 
 export interface ImportFormat {
-    value: "csv" | "padlock-legacy" | "lastpass" | "padloc" | "1pux";
+    value: "csv" | "padlock-legacy" | "lastpass" | "padloc" | "1pux" | "bitwarden";
     label: string;
 }
 
@@ -46,7 +47,12 @@ export const ONEPUX: ImportFormat = {
     label: "1Password (1pux)",
 };
 
-export const supportedFormats: ImportFormat[] = [CSV, PADLOCK_LEGACY, LASTPASS, PBES2, ONEPUX];
+export const BITWARDEN: ImportFormat = {
+    value: "bitwarden",
+    label: "Bitwarden (JSON)",
+};
+
+export const supportedFormats: ImportFormat[] = [CSV, PADLOCK_LEGACY, LASTPASS, PBES2, ONEPUX, BITWARDEN];
 
 export function loadPapa(): Promise<any> {
     return import(/* webpackChunkName: "papaparse" */ "papaparse");
@@ -425,10 +431,109 @@ export function is1Pux(file: File): boolean {
     return file.name.endsWith(".1pux");
 }
 
+async function parseBitwardenItem(
+    vaultName: string,
+    item: BitwardenItem,
+    folders: BitwardenExport["folders"]
+): Promise<VaultItem | undefined> {
+    if (!item) {
+        return;
+    }
+
+    const { parseToRowData } = await import("./bitwarden-parser");
+
+    const rowData = parseToRowData(item, [vaultName], folders);
+
+    if (!rowData) {
+        return;
+    }
+
+    const itemName = rowData.name;
+    const tags = rowData.tags.split(",");
+
+    const fields: Field[] = [];
+
+    if (rowData.username) {
+        fields.push(new Field({ name: $l("Username"), value: rowData.username, type: FieldType.Username }));
+    }
+
+    if (rowData.password) {
+        fields.push(new Field({ name: $l("Password"), value: rowData.password, type: FieldType.Password }));
+    }
+
+    if (rowData.url) {
+        fields.push(new Field({ name: $l("URL"), value: rowData.url, type: FieldType.Url }));
+    }
+
+    if (rowData.notes) {
+        fields.push(new Field({ name: $l("Notes"), value: rowData.notes, type: FieldType.Note }));
+    }
+
+    for (const extraField of rowData.extraFields) {
+        if (extraField.type === "totp") {
+            // Extract just the secret
+            try {
+                const secret = new URL(extraField.value).searchParams.get("secret");
+                if (secret) {
+                    fields.push(new Field({ name: extraField.name, value: secret, type: FieldType.Totp }));
+                }
+            } catch (error) {
+                // Do nothing
+            }
+        } else {
+            fields.push(
+                new Field({ name: extraField.name, value: extraField.value, type: extraField.type as FieldType })
+            );
+        }
+    }
+
+    return createVaultItem({ name: itemName, fields, tags });
+}
+
+export async function asBitwarden(file: File): Promise<VaultItem[]> {
+    try {
+        const { parseBitwardenFile } = await import("./bitwarden-parser");
+        const contents = await readFileAsText(file);
+        const dataExport = await parseBitwardenFile(contents);
+
+        const items = [];
+
+        for (const vaultItem of dataExport.items) {
+            if (vaultItem) {
+                const parsedItem = await parseBitwardenItem(
+                    file.name.replace(".json", ""),
+                    vaultItem,
+                    dataExport.folders
+                );
+                if (parsedItem) {
+                    items.push(parsedItem);
+                }
+            }
+        }
+
+        return items;
+    } catch (error) {
+        throw new Err(ErrorCode.INVALID_BITWARDEN, "Failed to parse Bitwarden .json file.");
+    }
+}
+
+export async function isBitwarden(file: File): Promise<boolean> {
+    try {
+        const content = await readFileAsText(file);
+        const data = JSON.parse(content);
+        return Object.prototype.hasOwnProperty.call(data, "items");
+    } catch (error) {
+        return false;
+    }
+}
+
 export async function guessFormat(file: File): Promise<ImportFormat> {
-    // Try to guess sync first (won't need parsing)
+    // Try to guess 1pux first (won't need parsing)
     if (is1Pux(file)) {
         return ONEPUX;
+    }
+    if (await isBitwarden(file)) {
+        return BITWARDEN;
     }
     if (await isPBES2Container(file)) {
         return PBES2;

--- a/packages/core/src/error.ts
+++ b/packages/core/src/error.ts
@@ -51,6 +51,7 @@ export enum ErrorCode {
     NOT_FOUND = "not_found",
     INVALID_CSV = "invalid_csv",
     INVALID_1PUX = "invalid_1pux",
+    INVALID_BITWARDEN = "invalid_bitwarden",
 
     BILLING_ERROR = "billing_error",
 

--- a/packages/locale/res/translations/_template.json
+++ b/packages/locale/res/translations/_template.json
@@ -1948,7 +1948,7 @@
     ""
   ],
   [
-    "You don't have any expiring or expired items!",
+    "You don't have any expired items!",
     ""
   ],
   [
@@ -1976,7 +1976,23 @@
     ""
   ],
   [
-    "Expiring or expired items are those that have been identified as being close to or past their set expiry date, which haven't been updated in a manually set number of days. These items should be rotated as soon as possible.",
+    "Expired items are those that have been identified as being past their set expiry date, which haven't been updated in a given number of days. These items should be rotated as soon as possible.",
+    ""
+  ],
+  [
+    "Card Number",
+    ""
+  ],
+  [
+    "Card Owner",
+    ""
+  ],
+  [
+    "Valid Until",
+    ""
+  ],
+  [
+    "CVC",
     ""
   ],
   [
@@ -2133,22 +2149,6 @@
   ],
   [
     "Credit Card",
-    ""
-  ],
-  [
-    "Card Number",
-    ""
-  ],
-  [
-    "Card Owner",
-    ""
-  ],
-  [
-    "Valid Until",
-    ""
-  ],
-  [
-    "CVC",
     ""
   ],
   [

--- a/packages/locale/res/translations/de.json
+++ b/packages/locale/res/translations/de.json
@@ -1948,7 +1948,7 @@
     ""
   ],
   [
-    "You don't have any expiring or expired items!",
+    "You don't have any expired items!",
     ""
   ],
   [
@@ -1976,8 +1976,24 @@
     ""
   ],
   [
-    "Expiring or expired items are those that have been identified as being close to or past their set expiry date, which haven't been updated in a manually set number of days. These items should be rotated as soon as possible.",
+    "Expired items are those that have been identified as being past their set expiry date, which haven't been updated in a given number of days. These items should be rotated as soon as possible.",
     ""
+  ],
+  [
+    "Card Number",
+    "Kartennummer"
+  ],
+  [
+    "Card Owner",
+    "Karteninhaber"
+  ],
+  [
+    "Valid Until",
+    "Gültig Bis"
+  ],
+  [
+    "CVC",
+    "Sicherheitscode"
   ],
   [
     "Notes",
@@ -2134,22 +2150,6 @@
   [
     "Credit Card",
     "Kreditkarte"
-  ],
-  [
-    "Card Number",
-    "Kartennummer"
-  ],
-  [
-    "Card Owner",
-    "Karteninhaber"
-  ],
-  [
-    "Valid Until",
-    "Gültig Bis"
-  ],
-  [
-    "CVC",
-    "Sicherheitscode"
   ],
   [
     "Bank Account",

--- a/packages/locale/res/translations/es.json
+++ b/packages/locale/res/translations/es.json
@@ -1948,7 +1948,7 @@
     ""
   ],
   [
-    "You don't have any expiring or expired items!",
+    "You don't have any expired items!",
     ""
   ],
   [
@@ -1976,8 +1976,24 @@
     ""
   ],
   [
-    "Expiring or expired items are those that have been identified as being close to or past their set expiry date, which haven't been updated in a manually set number of days. These items should be rotated as soon as possible.",
+    "Expired items are those that have been identified as being past their set expiry date, which haven't been updated in a given number of days. These items should be rotated as soon as possible.",
     ""
+  ],
+  [
+    "Card Number",
+    "Número de Tarjeta"
+  ],
+  [
+    "Card Owner",
+    "Dueño de la Tarjeta"
+  ],
+  [
+    "Valid Until",
+    "Válido Hasta"
+  ],
+  [
+    "CVC",
+    "CVC"
   ],
   [
     "Notes",
@@ -2134,22 +2150,6 @@
   [
     "Credit Card",
     "Tarjeta de Crédito"
-  ],
-  [
-    "Card Number",
-    "Número de Tarjeta"
-  ],
-  [
-    "Card Owner",
-    "Dueño de la Tarjeta"
-  ],
-  [
-    "Valid Until",
-    "Válido Hasta"
-  ],
-  [
-    "CVC",
-    "CVC"
   ],
   [
     "Bank Account",

--- a/packages/locale/res/translations/fr.json
+++ b/packages/locale/res/translations/fr.json
@@ -1948,7 +1948,7 @@
     "Vous n'avez pas d'éléments avec des mots de passe compromis !"
   ],
   [
-    "You don't have any expiring or expired items!",
+    "You don't have any expired items!",
     ""
   ],
   [
@@ -1976,8 +1976,24 @@
     "Les mots de passe compromis sont ceux qui ont été identifiés comme ayant fait l'objet d'une fuite dans le passé en les comparant à une base de données de violations de données connues. Ces mots de passe ne peuvent plus être considérés comme sûrs et doivent être modifiés immédiatement."
   ],
   [
-    "Expiring or expired items are those that have been identified as being close to or past their set expiry date, which haven't been updated in a manually set number of days. These items should be rotated as soon as possible.",
+    "Expired items are those that have been identified as being past their set expiry date, which haven't been updated in a given number of days. These items should be rotated as soon as possible.",
     ""
+  ],
+  [
+    "Card Number",
+    "Numéro de carte"
+  ],
+  [
+    "Card Owner",
+    "Propriétaire de la carte"
+  ],
+  [
+    "Valid Until",
+    "Valable jusqu'au"
+  ],
+  [
+    "CVC",
+    "CVV"
   ],
   [
     "Notes",
@@ -2134,22 +2150,6 @@
   [
     "Credit Card",
     "Carte de crédit"
-  ],
-  [
-    "Card Number",
-    "Numéro de carte"
-  ],
-  [
-    "Card Owner",
-    "Propriétaire de la carte"
-  ],
-  [
-    "Valid Until",
-    "Valable jusqu'au"
-  ],
-  [
-    "CVC",
-    "CVV"
   ],
   [
     "Bank Account",

--- a/packages/locale/res/translations/it.json
+++ b/packages/locale/res/translations/it.json
@@ -1948,7 +1948,7 @@
     "Non hai elementi con password compromesse!"
   ],
   [
-    "You don't have any expiring or expired items!",
+    "You don't have any expired items!",
     ""
   ],
   [
@@ -1976,8 +1976,24 @@
     "Le password compromesse sono quelle che sono state identificate come trapelate in passato confrontandole con un database di violazioni di dati noti. Queste password non possono più essere considerate sicure e devono essere modificate immediatamente."
   ],
   [
-    "Expiring or expired items are those that have been identified as being close to or past their set expiry date, which haven't been updated in a manually set number of days. These items should be rotated as soon as possible.",
+    "Expired items are those that have been identified as being past their set expiry date, which haven't been updated in a given number of days. These items should be rotated as soon as possible.",
     ""
+  ],
+  [
+    "Card Number",
+    "Numero Carta"
+  ],
+  [
+    "Card Owner",
+    "Intestatario Carta"
+  ],
+  [
+    "Valid Until",
+    "Valida fino al"
+  ],
+  [
+    "CVC",
+    "CVC"
   ],
   [
     "Notes",
@@ -2134,22 +2150,6 @@
   [
     "Credit Card",
     "Carta di Credito"
-  ],
-  [
-    "Card Number",
-    "Numero Carta"
-  ],
-  [
-    "Card Owner",
-    "Intestatario Carta"
-  ],
-  [
-    "Valid Until",
-    "Valida fino al"
-  ],
-  [
-    "CVC",
-    "CVC"
   ],
   [
     "Bank Account",

--- a/packages/locale/res/translations/pl.json
+++ b/packages/locale/res/translations/pl.json
@@ -1948,7 +1948,7 @@
     ""
   ],
   [
-    "You don't have any expiring or expired items!",
+    "You don't have any expired items!",
     ""
   ],
   [
@@ -1976,8 +1976,24 @@
     ""
   ],
   [
-    "Expiring or expired items are those that have been identified as being close to or past their set expiry date, which haven't been updated in a manually set number of days. These items should be rotated as soon as possible.",
+    "Expired items are those that have been identified as being past their set expiry date, which haven't been updated in a given number of days. These items should be rotated as soon as possible.",
     ""
+  ],
+  [
+    "Card Number",
+    "Numer karty"
+  ],
+  [
+    "Card Owner",
+    "Właściciel karty"
+  ],
+  [
+    "Valid Until",
+    "Ważna do"
+  ],
+  [
+    "CVC",
+    "CVC"
   ],
   [
     "Notes",
@@ -2134,22 +2150,6 @@
   [
     "Credit Card",
     "Karta kredytowa"
-  ],
-  [
-    "Card Number",
-    "Numer karty"
-  ],
-  [
-    "Card Owner",
-    "Właściciel karty"
-  ],
-  [
-    "Valid Until",
-    "Ważna do"
-  ],
-  [
-    "CVC",
-    "CVC"
   ],
   [
     "Bank Account",

--- a/packages/locale/res/translations/ru.json
+++ b/packages/locale/res/translations/ru.json
@@ -1948,7 +1948,7 @@
     ""
   ],
   [
-    "You don't have any expiring or expired items!",
+    "You don't have any expired items!",
     ""
   ],
   [
@@ -1976,8 +1976,24 @@
     ""
   ],
   [
-    "Expiring or expired items are those that have been identified as being close to or past their set expiry date, which haven't been updated in a manually set number of days. These items should be rotated as soon as possible.",
+    "Expired items are those that have been identified as being past their set expiry date, which haven't been updated in a given number of days. These items should be rotated as soon as possible.",
     ""
+  ],
+  [
+    "Card Number",
+    "Номер карты"
+  ],
+  [
+    "Card Owner",
+    "Владелец карты"
+  ],
+  [
+    "Valid Until",
+    "Действительно до"
+  ],
+  [
+    "CVC",
+    "CVC"
   ],
   [
     "Notes",
@@ -2134,22 +2150,6 @@
   [
     "Credit Card",
     "Кредитная карта"
-  ],
-  [
-    "Card Number",
-    "Номер карты"
-  ],
-  [
-    "Card Owner",
-    "Владелец карты"
-  ],
-  [
-    "Valid Until",
-    "Действительно до"
-  ],
-  [
-    "CVC",
-    "CVC"
   ],
   [
     "Bank Account",

--- a/packages/locale/res/translations/tr.json
+++ b/packages/locale/res/translations/tr.json
@@ -1948,7 +1948,7 @@
     "Tehlikeli parola içeren hiçbir kaydınız yok!"
   ],
   [
-    "You don't have any expiring or expired items!",
+    "You don't have any expired items!",
     ""
   ],
   [
@@ -1976,8 +1976,24 @@
     "Tehlikeli parolalar, bilinen veri ihlallerinden oluşan bir veritabanıyla karşılaştırılarak geçmişte sızdırıldığı belirlenen parolalardır. Bu parolalar artık güvenli kabul edilmez ve hemen değiştirilmelidir."
   ],
   [
-    "Expiring or expired items are those that have been identified as being close to or past their set expiry date, which haven't been updated in a manually set number of days. These items should be rotated as soon as possible.",
+    "Expired items are those that have been identified as being past their set expiry date, which haven't been updated in a given number of days. These items should be rotated as soon as possible.",
     ""
+  ],
+  [
+    "Card Number",
+    "Kart Numarası"
+  ],
+  [
+    "Card Owner",
+    "Kart Sahibi"
+  ],
+  [
+    "Valid Until",
+    "Geçerlilik Tarihi"
+  ],
+  [
+    "CVC",
+    "CVC"
   ],
   [
     "Notes",
@@ -2134,22 +2150,6 @@
   [
     "Credit Card",
     "Kredi Kartı"
-  ],
-  [
-    "Card Number",
-    "Kart Numarası"
-  ],
-  [
-    "Card Owner",
-    "Kart Sahibi"
-  ],
-  [
-    "Valid Until",
-    "Geçerlilik Tarihi"
-  ],
-  [
-    "CVC",
-    "CVC"
   ],
   [
     "Bank Account",

--- a/packages/locale/res/translations/tw.json
+++ b/packages/locale/res/translations/tw.json
@@ -1948,7 +1948,7 @@
     "您沒有任何項目含有已洩漏密碼！"
   ],
   [
-    "You don't have any expiring or expired items!",
+    "You don't have any expired items!",
     ""
   ],
   [
@@ -1976,8 +1976,24 @@
     "已洩漏的密碼表示在資料庫中比對出相同的外洩密碼。這些密碼已經不再安全且應該被立即更改。"
   ],
   [
-    "Expiring or expired items are those that have been identified as being close to or past their set expiry date, which haven't been updated in a manually set number of days. These items should be rotated as soon as possible.",
+    "Expired items are those that have been identified as being past their set expiry date, which haven't been updated in a given number of days. These items should be rotated as soon as possible.",
     ""
+  ],
+  [
+    "Card Number",
+    "卡號"
+  ],
+  [
+    "Card Owner",
+    "卡片擁有者"
+  ],
+  [
+    "Valid Until",
+    "有效期"
+  ],
+  [
+    "CVC",
+    "安全碼"
   ],
   [
     "Notes",
@@ -2134,22 +2150,6 @@
   [
     "Credit Card",
     "信用卡"
-  ],
-  [
-    "Card Number",
-    "卡號"
-  ],
-  [
-    "Card Owner",
-    "卡片擁有者"
-  ],
-  [
-    "Valid Until",
-    "有效期"
-  ],
-  [
-    "CVC",
-    "安全碼"
   ],
   [
     "Bank Account",


### PR DESCRIPTION
This should support all fields and data (except attachments, which aren't exported), for the JSON (unencrypted) format.

[You can get the sample Bitwarden provides](https://bitwarden.com/help/condition-bitwarden-import/#condition-a-json) to test (their totp example doesn't seem to match their expectation on their clients' source code because they still look for a `secret` search param).

Fixes #561 