### PR TITLE
Automatically update Dockerhub images on merge

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -29,7 +29,7 @@ jobs:
         outputs:
             release_id: ${{ steps.create_release.outputs.id }}
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
             - uses: actions/setup-node@v2
               with:
                   node-version-file: ".nvmrc"
@@ -61,7 +61,7 @@ jobs:
 
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
             - uses: actions/setup-node@v2
               with:
                   node-version-file: ".nvmrc"
@@ -152,7 +152,7 @@ jobs:
 
         runs-on: ${{ matrix.platform }}
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
             - uses: actions/setup-node@v2
               with:
                   node-version-file: ".nvmrc"
@@ -260,7 +260,7 @@ jobs:
 
         runs-on: ${{ matrix.platform }}
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
             - uses: actions/setup-node@v2
               with:
                   node-version-file: ".nvmrc"
@@ -398,7 +398,7 @@ jobs:
 
         runs-on: ${{ matrix.platform }}
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
             - uses: actions/setup-java@v1
               if: matrix.platform == 'ubuntu-latest'
               with:
@@ -549,7 +549,7 @@ jobs:
 
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
             - uses: actions/setup-node@v2
               with:
                   node-version-file: ".nvmrc"
@@ -595,3 +595,29 @@ jobs:
                   file: docs/checksums/web/parse-csp.ts
                   asset_name: parse-csp.ts
                   prerelease: true
+
+    update_dockerhub:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Check out the repo
+              uses: actions/checkout@v3
+
+            - name: Log in to Docker Hub
+              uses: docker/login-action@v2
+              with:
+                  username: ${{ secrets.DOCKER_USERNAME }}
+                  password: ${{ secrets.DOCKER_PASSWORD }}
+
+            - name: Build and push Docker image (server)
+              uses: docker/build-push-action@v3
+              with:
+                  push: true
+                  tags: padloc/server:v${{ env.PL_VENDOR_VERSION }}
+                  file: Dockerfile-server
+
+            - name: Build and push Docker image (pwa)
+              uses: docker/build-push-action@v3
+              with:
+                  push: true
+                  tags: padloc/pwa:v${{ env.PL_VENDOR_VERSION }}
+                  file: Dockerfile-pwa

--- a/.github/workflows/update-dockerhub.yml
+++ b/.github/workflows/update-dockerhub.yml
@@ -1,0 +1,40 @@
+name: Update Dockerhub
+
+on:
+    workflow_dispatch:
+
+    push:
+        branches:
+            - "main"
+        paths:
+            - "packages/app/**"
+            - "packages/core/**"
+            - "packages/locale/**"
+            - "assets/**"
+
+jobs:
+    update_dockerhub:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Check out the repo
+              uses: actions/checkout@v3
+
+            - name: Log in to Docker Hub
+              uses: docker/login-action@v2
+              with:
+                  username: ${{ secrets.DOCKER_USERNAME }}
+                  password: ${{ secrets.DOCKER_PASSWORD }}
+
+            - name: Build and push Docker image (server)
+              uses: docker/build-push-action@v3
+              with:
+                  push: true
+                  tags: padloc/server:latest
+                  file: Dockerfile-server
+
+            - name: Build and push Docker image (pwa)
+              uses: docker/build-push-action@v3
+              with:
+                  push: true
+                  tags: padloc/pwa:latest
+                  file: Dockerfile-pwa


### PR DESCRIPTION
For the `main` branch and on release publishing as well.

Fixes #583 