### PR TITLE
Support iCloud/Safari Passwords, Chrome, and Firefox CSV exports

### DIFF
--- a/packages/app/src/elements/import-dialog.ts
+++ b/packages/app/src/elements/import-dialog.ts
@@ -321,6 +321,15 @@ export class ImportDialog extends Dialog<File, void> {
             case imp.NORDPASS.value:
                 this._items = await imp.asNordPass(file);
                 break;
+            case imp.ICLOUD.value:
+                this._items = await imp.asICloud(file);
+                break;
+            case imp.CHROME.value:
+                this._items = await imp.asChrome(file);
+                break;
+            case imp.FIREFOX.value:
+                this._items = await imp.asFirefox(file);
+                break;
             case imp.PBES2.value:
                 this.open = false;
                 const pwd2 = await prompt($l("This file is protected by a password."), {


### PR DESCRIPTION
This closes #347 because Brave and Edge use the same format as Chrome.

Sample files:
- [icloud_passwords_sample.csv](https://github.com/padloc/padloc/files/9556707/icloud_passwords_sample.csv)
- [chrome_passwords_sample.csv](https://github.com/padloc/padloc/files/9556708/chrome_passwords_sample.csv)
- [firefox_passwords_sample.csv](https://github.com/padloc/padloc/files/9556710/firefox_passwords_sample.csv)

