### PR TITLE
Enable running tests on PRs from forks

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,6 +1,10 @@
 name: Run Tests
 
-on: [push]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
     test:


### PR DESCRIPTION
Otherwise we only run the tests after merging, and that's not helpful.