### PR TITLE
Add configurable healthcheck endpoint

### DIFF
--- a/docs/examples/config/example.env
+++ b/docs/examples/config/example.env
@@ -12,7 +12,7 @@
 # PL_TRANSPORT_HTTP_PORT=3000
 # PL_TRANSPORT_HTTP_MAX_REQUEST_SIZE=1e9
 # PL_TRANSPORT_HTTP_ALLOW_ORIGIN=*
-# PL_TRANSPORT_HTTP_HEALTHCHECK_PATH=/healthcheck
+# PL_TRANSPORT_HTTP_HEALTH_CHECK_PATH=/healthcheck
 
 
 # =============================================================================

--- a/docs/examples/config/example.env
+++ b/docs/examples/config/example.env
@@ -320,6 +320,7 @@
 # PL_SERVER_DEFAULT_AUTH_TYPES=email
 # PL_SERVER_DISABLE_SIGNUP=false
 # PL_SERVER_SCIM_SERVER_URL=http://localhost:5000
+# PL_SERVER_HEALTHCHECK_PATH=/healthcheck
 
 # =============================================================================
 # PWA

--- a/docs/examples/config/example.env
+++ b/docs/examples/config/example.env
@@ -12,6 +12,7 @@
 # PL_TRANSPORT_HTTP_PORT=3000
 # PL_TRANSPORT_HTTP_MAX_REQUEST_SIZE=1e9
 # PL_TRANSPORT_HTTP_ALLOW_ORIGIN=*
+# PL_TRANSPORT_HTTP_HEALTHCHECK_PATH=/healthcheck
 
 
 # =============================================================================
@@ -320,7 +321,6 @@
 # PL_SERVER_DEFAULT_AUTH_TYPES=email
 # PL_SERVER_DISABLE_SIGNUP=false
 # PL_SERVER_SCIM_SERVER_URL=http://localhost:5000
-# PL_SERVER_HEALTHCHECK_PATH=/healthcheck
 
 # =============================================================================
 # PWA

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -88,10 +88,6 @@ export class ServerConfig extends Config {
     @ConfigParam()
     scimServerUrl = "http://localhost:5000";
 
-    /** Path on the server for responding with 200, to be used in health checks (e.g. load balancers) */
-    @ConfigParam()
-    healthcheckPath = "/healthcheck";
-
     constructor(init: Partial<ServerConfig> = {}) {
         super();
         Object.assign(this, init);
@@ -2007,17 +2003,6 @@ export class Server {
         const context: Context = {};
 
         const start = Date.now();
-
-        if (req.method.startsWith("GET:")) {
-            if (req.method === `GET:${this.config.healthcheckPath}`) {
-                res.result = 200;
-                return res;
-            }
-
-            // Reject non-healthcheck GET requests with legacy response
-            res.result = 405;
-            return res;
-        }
 
         try {
             context.device = req.device;

--- a/packages/server/src/transport/http.ts
+++ b/packages/server/src/transport/http.ts
@@ -42,7 +42,7 @@ export class HTTPReceiverConfig extends Config {
 
     /** Path on the HTTP server for responding with 200, to be used in health checks (e.g. load balancers) */
     @ConfigParam()
-    healthcheckPath = "/healthcheck";
+    healthCheckPath = "/healthcheck";
 }
 
 export class HTTPReceiver implements Receiver {
@@ -66,7 +66,7 @@ export class HTTPReceiver implements Receiver {
                 case "GET":
                     // httpReq.url will include searchParams, so we parse the pathname properly
                     const url = new URL(`http://localhost${httpReq.url || ""}`);
-                    if (url.pathname === this.config.healthcheckPath) {
+                    if (url.pathname === this.config.healthCheckPath) {
                         httpRes.statusCode = 200;
                     } else {
                         // Legacy server response for GET requests

--- a/packages/server/src/transport/http.ts
+++ b/packages/server/src/transport/http.ts
@@ -59,6 +59,20 @@ export class HTTPReceiver implements Receiver {
                 case "OPTIONS":
                     httpRes.end();
                     break;
+                case "GET":
+                    try {
+                        const req = new Request();
+                        // httpReq.url will include searchParams, so we parse the pathname properly
+                        const url = new URL(`http://localhost${httpReq.url || ""}`);
+                        req.method = `GET:${url.pathname}`;
+                        const res = await handler(req);
+                        httpRes.statusCode = res.result;
+                    } catch (error) {
+                        console.error(error);
+                        httpRes.statusCode = 400;
+                    }
+                    httpRes.end();
+                    break;
                 case "POST":
                     try {
                         const body = await readBody(httpReq, this.config.maxRequestSize);


### PR DESCRIPTION
Defaults to `/healthcheck` and can be configured via `PL_SERVER_HEALTHCHECK_PATH`, which will return a 200 status code response for a `GET` request.

Fixes #279