### PR TITLE
Add PWA URL to basic docker example

### DIFF
--- a/docs/examples/hosting/docker/basic/docker-compose.yml
+++ b/docs/examples/hosting/docker/basic/docker-compose.yml
@@ -11,6 +11,7 @@ services:
             PL_DATA_ATTACHMENTS_BACKEND: fs
             PL_DATA_ATTACHMENTS_DIR: /attachments
             PL_SERVER_CLIENT_URL: http://localhost:8080
+            PL_EMAIL_BACKEND: console
         ports:
             - 3000:3000
         volumes:
@@ -24,6 +25,7 @@ services:
             dockerfile: Dockerfile-pwa
         environment:
             PL_SERVER_URL: http://localhost:3000
+            PL_PWA_URL: http://localhost:8080
         ports:
             - 8080:8080
         restart: on-failure

--- a/packages/core/src/auth/email.ts
+++ b/packages/core/src/auth/email.ts
@@ -1,6 +1,5 @@
 import { Auth, Authenticator, AuthenticatorStatus, AuthRequest, AuthServer, AuthType } from "../auth";
-import { Messenger } from "../messenger";
-import { EmailAuthMessage } from "../messenger";
+import { Messenger, EmailAuthMessage } from "../messenger";
 import { ErrorCode, Err } from "../error";
 import { randomNumber } from "../util";
 


### PR DESCRIPTION
Also include `PL_EMAIL_BACKEND=console` just to make it simpler to try this out locally and have it just work end-to-end.

Based on recommendations at https://github.com/padloc/padloc/issues/605#issuecomment-1272318133