### PR TITLE
Caddy Docker Example

### DIFF
--- a/docs/examples/hosting/docker/README.md
+++ b/docs/examples/hosting/docker/README.md
@@ -5,4 +5,5 @@ app via Docker.
 
 -   [Basic Example](basic)
 -   [Example of using **NGINX** as a reverse proxy](nginx)
+-   [Example of using **Caddy** as a reverse proxy](caddy)
 -   [Advanced Example using **Postgres**, **NGINX** and **Letsencrypt**](postgres-nginx-letsencrypt)

--- a/docs/examples/hosting/docker/caddy/Caddyfile
+++ b/docs/examples/hosting/docker/caddy/Caddyfile
@@ -1,0 +1,28 @@
+localhost {
+    encode gzip zstd
+
+    handle_path /server* {
+        reverse_proxy * server:3000 {
+            header_up Host {host}
+            header_up X-Real-IP {remote}
+            # header_up X-Forwarded-For {remote}
+            header_up X-Forwarded-Host {upstream_hostport}
+        }
+    }
+
+    handle {
+        root * /pwa
+    
+        file_server
+
+        try_files {path} /index.html
+
+        header {
+            X-Frame-Options DENY
+        }
+
+        request_body {
+            max_size 10MB
+        }
+    }
+}

--- a/docs/examples/hosting/docker/caddy/README.md
+++ b/docs/examples/hosting/docker/caddy/README.md
@@ -15,4 +15,6 @@ reverse proxy.
     docker-compose up
     ```
 
-That's it! The web app is now available at https://localhost (you will get a self-signed certificate error, which is expected, and you can safely accept/ignore).
+That's it! The web app is now available at https://localhost (you will get a
+self-signed certificate error, which is expected, and you can safely
+accept/ignore).

--- a/docs/examples/hosting/docker/caddy/README.md
+++ b/docs/examples/hosting/docker/caddy/README.md
@@ -1,0 +1,18 @@
+# Docker + Caddy
+
+This is a basic example of running an instance of the Padloc server component
+and web app with Docker Compose, using [Caddy](https://caddyserver.com/) as a
+reverse proxy.
+
+## Setup Instructions
+
+0. Install [Docker](https://docs.docker.com/get-docker/) and
+   [Docker Compose](https://docs.docker.com/compose/install/)
+1. Clone or download this folder and `cd` into it.
+2. Start the server and pwa:
+
+    ```sh
+    docker-compose up
+    ```
+
+That's it! The web app is now available at https://localhost (you will get a self-signed certificate error, which is expected, and you can safely accept/ignore).

--- a/docs/examples/hosting/docker/caddy/docker-compose.yml
+++ b/docs/examples/hosting/docker/caddy/docker-compose.yml
@@ -1,0 +1,47 @@
+version: "3.7"
+services:
+    server:
+        image: padloc/server
+        build:
+            context: github.com/padloc/padloc.git#main
+            dockerfile: Dockerfile-server
+        environment:
+            PL_DATA_BACKEND: leveldb
+            PL_DATA_LEVELDB_DIR: /data
+            PL_DATA_ATTACHMENTS_BACKEND: fs
+            PL_DATA_ATTACHMENTS_DIR: /attachments
+            PL_SERVER_CLIENT_URL: https://localhost
+        expose:
+            - 3000
+        volumes:
+            - attachments:/attachments
+            - data:/data
+        restart: unless-stopped
+    pwa:
+        image: padloc/pwa
+        environment:
+            PL_SERVER_URL: https://localhost/server
+            PL_PWA_URL: https://localhost
+            PL_PWA_PORT: 443
+        build:
+            context: github.com/padloc/padloc.git#main
+            dockerfile: Dockerfile-pwa
+        volumes:
+            - pwa:/pwa
+        command: ["build"]
+        restart: on-failure
+    caddy:
+        image: caddy:2
+        depends_on:
+            - server
+        restart: always
+        volumes:
+            - pwa:/pwa
+            - ./Caddyfile:/etc/caddy/Caddyfile
+        ports:
+            - 80:80
+            - 443:443
+volumes:
+    data:
+    attachments:
+    pwa:


### PR DESCRIPTION
This adds a working example for using Padloc with Caddy, which automatically handles SSL/HTTPS.