### PR TITLE
Add oauth authenticator and provisioner

### DIFF
--- a/packages/app/src/elements/alert-dialog.ts
+++ b/packages/app/src/elements/alert-dialog.ts
@@ -22,6 +22,7 @@ export interface AlertOptions {
     width?: string;
     hideOnDocumentVisibilityChange?: boolean;
     zIndex?: number;
+    doneHandler?: (choice: number) => void;
 }
 
 @customElement("pl-alert-dialog")
@@ -44,6 +45,8 @@ export class AlertDialog extends Dialog<AlertOptions, number> {
     maxWidth?: string;
     @property()
     width?: string;
+    @property()
+    doneHandler?: (choice: number) => void;
 
     static styles = [
         ...Dialog.styles,
@@ -106,6 +109,7 @@ export class AlertDialog extends Dialog<AlertOptions, number> {
     }
 
     done(i: number = -1) {
+        this.doneHandler?.(i);
         super.done(i);
     }
 
@@ -122,6 +126,7 @@ export class AlertDialog extends Dialog<AlertOptions, number> {
         width,
         hideOnDocumentVisibilityChange = false,
         zIndex = 10,
+        doneHandler = undefined,
     }: AlertOptions = {}): Promise<number> {
         this.message = message;
         this.dialogTitle = title;
@@ -135,6 +140,7 @@ export class AlertDialog extends Dialog<AlertOptions, number> {
         }
         this.maxWidth = maxWidth;
         this.width = width;
+        this.doneHandler = doneHandler;
 
         const promise = super.show();
 

--- a/packages/app/src/elements/app.ts
+++ b/packages/app/src/elements/app.ts
@@ -102,7 +102,9 @@ export class App extends ServiceWorker(StateMixin(AutoSync(ErrorHandling(AutoLoc
             const params = url.searchParams;
             const error = params.get("error");
             if (error) {
-                await alert(error, { type: "warning", title: $l("Something went wrong") });
+                alert(error, { type: "warning" });
+                this.go("", { error: undefined, code: undefined, state: undefined }, true);
+                return;
             }
             const code = params.get("code");
             const state = params.get("state") || undefined;

--- a/packages/app/src/elements/app.ts
+++ b/packages/app/src/elements/app.ts
@@ -42,9 +42,6 @@ export class App extends ServiceWorker(StateMixin(AutoSync(ErrorHandling(AutoLoc
     @property({ type: Boolean, reflect: true, attribute: "singleton-container" })
     readonly singletonContainer = true;
 
-    @state()
-    protected _ready = false;
-
     @dialog("pl-create-org-dialog")
     private _createOrgDialog: CreateOrgDialog;
 
@@ -90,7 +87,6 @@ export class App extends ServiceWorker(StateMixin(AutoSync(ErrorHandling(AutoLoc
             app.fetchAccount();
             app.fetchAuthInfo();
         }
-        this._ready = true;
         // this.routeChanged();
         const spinner = document.querySelector(".spinner") as HTMLElement;
         spinner.style.display = "none";
@@ -111,7 +107,7 @@ export class App extends ServiceWorker(StateMixin(AutoSync(ErrorHandling(AutoLoc
             const code = params.get("code");
             const state = params.get("state") || undefined;
             const pendingAuthData = stringToBase64(JSON.stringify({ code, state }));
-            this.go("start", { pendingAuth: state, pendingAuthData });
+            this.go("start", { pendingAuth: state, pendingAuthData }, true);
             return;
         }
 

--- a/packages/app/src/elements/login-signup.ts
+++ b/packages/app/src/elements/login-signup.ts
@@ -128,6 +128,7 @@ export class LoginOrSignup extends StartForm {
             const { pendingAuth, pendingAuthData } = await this._getPendingAuth();
             if (pendingAuth) {
                 this._emailInput.value = pendingAuth.email;
+                this._submitEmailButton.stop();
                 this._submitEmail(pendingAuth, pendingAuthData);
             }
         }

--- a/packages/core/src/auth.ts
+++ b/packages/core/src/auth.ts
@@ -26,7 +26,7 @@ export enum AuthType {
     WebAuthnPortable = "webauthn_portable",
     Totp = "totp",
     PublicKey = "public_key",
-    OpenID = "openid",
+    Oauth = "oauth",
 }
 
 export enum AuthenticatorStatus {
@@ -156,7 +156,7 @@ export interface AuthServer {
 
     initAuthRequest(authenticator: Authenticator, request: AuthRequest, params?: any): Promise<any>;
 
-    verifyAuthRequest(authenticator: Authenticator, request: AuthRequest, params?: any): Promise<void>;
+    verifyAuthRequest(authenticator: Authenticator, request: AuthRequest, params?: any): Promise<any>;
 }
 
 export interface AuthClient {
@@ -234,6 +234,8 @@ export class Auth extends Serializable implements Storable {
 
     /** Completely disables mfa for a given account. Only use for testing! */
     disableMFA = false;
+
+    metaData?: any = undefined;
 
     constructor(public email: string = "") {
         super();

--- a/packages/core/src/platform.ts
+++ b/packages/core/src/platform.ts
@@ -118,7 +118,10 @@ export interface Platform {
         authenticatorIndex?: number;
     }): Promise<StartAuthRequestResponse>;
 
-    completeAuthRequest(req: StartAuthRequestResponse): Promise<{
+    completeAuthRequest(
+        req: StartAuthRequestResponse,
+        data?: any
+    ): Promise<{
         email: string;
         token: string;
         accountStatus: AccountStatus;
@@ -196,7 +199,10 @@ export class StubPlatform implements Platform {
         throw new Error("Method not implemented.");
     }
 
-    async completeAuthRequest(_req: StartAuthRequestResponse): Promise<{
+    async completeAuthRequest(
+        _req: StartAuthRequestResponse,
+        _data?: any
+    ): Promise<{
         email: string;
         token: string;
         accountStatus: AccountStatus;
@@ -296,7 +302,10 @@ export function startAuthRequest(opts: {
     return platform.startAuthRequest(opts);
 }
 
-export function completeAuthRequest(req: StartAuthRequestResponse): Promise<{
+export function completeAuthRequest(
+    req: StartAuthRequestResponse,
+    data?: any
+): Promise<{
     email: string;
     token: string;
     accountStatus: AccountStatus;
@@ -304,7 +313,7 @@ export function completeAuthRequest(req: StartAuthRequestResponse): Promise<{
     provisioning: AccountProvisioning;
     legacyData?: PBES2Container;
 }> {
-    return platform.completeAuthRequest(req);
+    return platform.completeAuthRequest(req, data);
 }
 
 export async function authenticate(opts: {

--- a/packages/core/src/provisioning.ts
+++ b/packages/core/src/provisioning.ts
@@ -143,6 +143,8 @@ export class AccountProvisioning extends Storable {
 
     email: string = "";
 
+    name?: string = undefined;
+
     accountId?: AccountID = undefined;
 
     status: ProvisioningStatus = ProvisioningStatus.Active;
@@ -156,6 +158,8 @@ export class AccountProvisioning extends Storable {
     actionLabel?: string = undefined;
 
     metaData?: any = undefined;
+
+    skipTos: boolean = false;
 
     billingPage?: RichContent = undefined;
 

--- a/packages/extension/src/app.ts
+++ b/packages/extension/src/app.ts
@@ -39,7 +39,6 @@ export class ExtensionApp extends App {
             const masterKey = await browser.runtime.sendMessage({ type: "requestMasterKey" });
             if (masterKey) {
                 await this.app.unlockWithMasterKey(base64ToBytes(masterKey));
-                this._ready = true;
                 this._unlocked();
             }
         }

--- a/packages/server/src/auth/oauth.ts
+++ b/packages/server/src/auth/oauth.ts
@@ -3,11 +3,12 @@ import { Config, ConfigParam } from "@padloc/core/src/config";
 import { AuthRequest, AuthServer, AuthType, Authenticator } from "@padloc/core/src/auth";
 import { request } from "../transport/http";
 import { Err, ErrorCode } from "@padloc/core/src/error";
-import { base64ToString, bytesToBase64, stringToBytes } from "@padloc/core/src/encoding";
+import { bytesToBase64, stringToBytes } from "@padloc/core/src/encoding";
 import { getCryptoProvider } from "@padloc/core/src/platform";
 import { HashParams } from "@padloc/core/src/crypto";
+import { NumberLiteralType } from "typescript";
 
-export class OpenIdConfig extends Config {
+export class OauthConfig extends Config {
     @ConfigParam()
     clientId!: string;
 
@@ -21,14 +22,28 @@ export class OpenIdConfig extends Config {
     tokenEndpoint!: string;
 
     @ConfigParam()
+    userInfoEndpoint!: string;
+
+    @ConfigParam()
     redirectUri!: string;
 }
 
-export class OpenIDServer implements AuthServer {
-    constructor(public config: OpenIdConfig) {}
+export type OauthTokenInfo = {
+    access_token: string;
+    expires_in: number;
+    refresh_token: string;
+    refresh_token_id: string;
+    token_type: "Bearer";
+    userId: string;
+};
+
+export type OauthUserInfo = { given_name: string; last_name: string; email: string };
+
+export class OauthServer implements AuthServer {
+    constructor(public config: OauthConfig) {}
 
     supportsType(type: AuthType): boolean {
-        return type === AuthType.OpenID;
+        return type === AuthType.Oauth;
     }
 
     async initAuthenticator(
@@ -38,40 +53,56 @@ export class OpenIDServer implements AuthServer {
     ): Promise<any> {
         authenticator.state = {
             email,
-            activationParams: await this._generateAuthUrl(email),
+            activationParams: await this._generateAuthUrl(email, authenticator.id),
         };
         return { authUrl: authenticator.state.activationParams.authUrl };
     }
 
-    async activateAuthenticator(authenticator: Authenticator<any>, { code }: { code: string }): Promise<any> {
-        const token = await this._getToken({ code, codeVerifier: authenticator.state.activationParams.codeVerifier });
-        if (token.email !== authenticator.state?.email) {
+    async activateAuthenticator(
+        authenticator: Authenticator<any>,
+        { code, state }: { code: string; state: string }
+    ): Promise<any> {
+        if (state !== authenticator.id) {
+            throw new Err(
+                ErrorCode.AUTHENTICATION_FAILED,
+                "There was something wrong with this request. Please try again!"
+            );
+        }
+        const { userInfo } = await this._getTokens({
+            code,
+            codeVerifier: authenticator.state.activationParams.codeVerifier,
+        });
+        if (userInfo.email !== authenticator.state?.email) {
             throw new Err(ErrorCode.AUTHENTICATION_FAILED, "Email returned from authenticator does not match.");
         }
-        authenticator.state.id_token = token;
     }
 
     async initAuthRequest(authenticator: Authenticator<any>, request: AuthRequest<any>, _params?: any): Promise<any> {
-        request.state = await this._generateAuthUrl(authenticator.state.email);
+        request.state = await this._generateAuthUrl(authenticator.state.email, request.id);
         return { authUrl: request.state.authUrl };
     }
 
     async verifyAuthRequest(
         authenticator: Authenticator<any>,
         request: AuthRequest<any>,
-        { code }: { code: string }
-    ): Promise<void> {
-        const token = await this._getToken({ code, codeVerifier: request.state.codeVerifier });
-        if (token.email !== authenticator.state?.email) {
+        { code, state }: { code: string; state: string }
+    ): Promise<any> {
+        if (state !== request.id) {
+            throw new Err(
+                ErrorCode.AUTHENTICATION_FAILED,
+                "There was something wrong with this request. Please try again!"
+            );
+        }
+        const res = await this._getTokens({ code, codeVerifier: request.state.codeVerifier });
+        if (res.userInfo.email !== authenticator.state?.email) {
             throw new Err(ErrorCode.AUTHENTICATION_FAILED, "Email returned from authenticator does not match.");
         }
-        authenticator.state.id_token = token;
+        return { oauth: res };
     }
 
-    private async _generateAuthUrl(email: string) {
+    private async _generateAuthUrl(email: string, state: string) {
         const { clientId, authorizationEndpoint, redirectUri } = this.config;
         const crypto = getCryptoProvider();
-        const state = bytesToBase64(await crypto.randomBytes(8));
         const nonce = bytesToBase64(await crypto.randomBytes(8));
         const codeVerifier = bytesToBase64(await crypto.randomBytes(32));
         const codeChallenge = bytesToBase64(
@@ -87,7 +118,7 @@ export class OpenIDServer implements AuthServer {
         params.set("client_id", clientId);
         params.set("response_type", "code");
         params.set("response_mode", "query");
-        params.set("scope", "openid email profile");
+        params.set("scope", "email offline_access");
         params.set("state", state);
         params.set("nonce", nonce);
         params.set("redirect_uri", redirectUri);
@@ -103,19 +134,22 @@ export class OpenIDServer implements AuthServer {
         };
     }
 
-    private async _parseToken(token: string) {
-        const [_header, payload, _signature] = token.split(".");
-        return JSON.parse(base64ToString(payload));
-    }
+    // private async _parseToken(token: string) {
+    //     const [_header, payload, _signature] = token.split(".");
+    //     return JSON.parse(base64ToString(payload));
+    // }
 
-    private async _getToken({ code, codeVerifier }: { code: string; codeVerifier: string }) {
+    private async _getTokens({ code, codeVerifier }: { code: string; codeVerifier: string }): Promise<{
+        tokens: OauthTokenInfo;
+        userInfo: OauthUserInfo;
+    }> {
         const body = new URLSearchParams({
             client_id: this.config.clientId,
             client_secret: this.config.clientSecret,
             grant_type: "authorization_code",
             code,
             code_verifier: codeVerifier,
-            scope: "openid profile email",
+            scope: "email offline_access",
             redirect_uri: this.config.redirectUri,
         }).toString();
 
@@ -126,17 +160,13 @@ export class OpenIDServer implements AuthServer {
                 "Content-Length": body.length.toString(),
             });
 
-            const { id_token } = JSON.parse(tokenRes);
+            const tokens = JSON.parse(tokenRes);
+            const userInfo = await request(this.config.userInfoEndpoint, "GET", undefined, {
+                Accept: "application/json",
+                Authorization: `Bearer ${tokens.access_token}`,
+            });
 
-            if (!id_token) {
-                throw new Err(ErrorCode.AUTHENTICATION_FAILED, "No id token was returned.");
-            }
-
-            try {
-                return this._parseToken(id_token);
-            } catch (e) {
-                throw new Err(ErrorCode.AUTHENTICATION_FAILED, "Failed to parse ID token.");
-            }
+            return { tokens, userInfo: JSON.parse(userInfo) };
         } catch (e) {
             throw new Err(ErrorCode.AUTHENTICATION_FAILED, "Failed to retrieve auth token.");
         }

--- a/packages/server/src/auth/oauth.ts
+++ b/packages/server/src/auth/oauth.ts
@@ -6,7 +6,6 @@ import { Err, ErrorCode } from "@padloc/core/src/error";
 import { bytesToBase64, stringToBytes } from "@padloc/core/src/encoding";
 import { getCryptoProvider } from "@padloc/core/src/platform";
 import { HashParams } from "@padloc/core/src/crypto";
-import { NumberLiteralType } from "typescript";
 
 export class OauthConfig extends Config {
     @ConfigParam()
@@ -37,7 +36,12 @@ export type OauthTokenInfo = {
     userId: string;
 };
 
-export type OauthUserInfo = { given_name: string; last_name: string; email: string };
+export type OauthUserInfo = {
+    email: string;
+    name?: string;
+    given_name?: string;
+    family_name?: string;
+};
 
 export class OauthServer implements AuthServer {
     constructor(public config: OauthConfig) {}

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -7,7 +7,7 @@ import { WebAuthnConfig } from "./auth/webauthn";
 import { LevelDBStorageConfig } from "./storage/leveldb";
 import { MongoDBStorageConfig } from "./storage/mongodb";
 import { AuthType } from "@padloc/core/src/auth";
-import { OpenIdConfig } from "./auth/openid";
+import { OauthConfig } from "./auth/oauth";
 import { TotpAuthConfig } from "@padloc/core/src/auth/totp";
 import { StripeProvisionerConfig } from "./provisioning/stripe";
 import { DirectoryProvisionerConfig } from "./provisioning/directory";
@@ -114,8 +114,8 @@ export class AuthConfig extends Config {
     @ConfigParam(TotpAuthConfig)
     totp?: TotpAuthConfig;
 
-    @ConfigParam(OpenIdConfig)
-    openid?: OpenIdConfig;
+    @ConfigParam(OauthConfig)
+    oauth?: OauthConfig;
 }
 
 export class ProvisioningConfig extends Config {

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -19,6 +19,7 @@ import { resolve } from "path";
 import { ScimServerConfig } from "./scim";
 import { BasicProvisionerConfig } from "@padloc/core/src/provisioning";
 import { ChangeLoggerConfig, RequestLoggerConfig } from "@padloc/core/src/logging";
+import { OauthProvisionerConfig } from "./provisioning/oauth";
 
 export class TransportConfig extends Config {
     @ConfigParam()
@@ -120,7 +121,7 @@ export class AuthConfig extends Config {
 
 export class ProvisioningConfig extends Config {
     @ConfigParam()
-    backend: "basic" | "directory" | "stripe" = "basic";
+    backend: "basic" | "directory" | "stripe" | "oauth" = "basic";
 
     @ConfigParam(BasicProvisionerConfig)
     basic?: BasicProvisionerConfig;
@@ -130,6 +131,9 @@ export class ProvisioningConfig extends Config {
 
     @ConfigParam(DirectoryProvisionerConfig)
     directory?: DirectoryProvisionerConfig;
+
+    @ConfigParam(OauthProvisionerConfig)
+    oauth?: OauthProvisionerConfig;
 }
 
 export class DirectoryConfig extends Config {

--- a/packages/server/src/provisioning/oauth.ts
+++ b/packages/server/src/provisioning/oauth.ts
@@ -1,0 +1,145 @@
+import {
+    AccountProvisioning,
+    BasicProvisioner,
+    BasicProvisionerConfig,
+    Provisioning,
+    ProvisioningStatus,
+} from "@padloc/core/src/provisioning";
+import { getIdFromEmail } from "@padloc/core/src/util";
+import { Storage } from "@padloc/core/src/storage";
+import { ConfigParam } from "@padloc/core/src/config";
+import { request } from "../transport/http";
+import { AccountID } from "@padloc/core/src/account";
+import { Auth } from "@padloc/core/src/auth";
+import { OauthConfig, OauthUserInfo } from "../auth/oauth";
+
+export class OauthProvisionerConfig extends BasicProvisionerConfig {
+    @ConfigParam("number")
+    resyncAfter: number = 10;
+}
+
+export class OauthProvisioner extends BasicProvisioner {
+    constructor(
+        readonly storage: Storage,
+        readonly config: OauthProvisionerConfig,
+        public readonly oauthConfig: OauthConfig
+    ) {
+        super(storage, config);
+    }
+
+    async orgDeleted() {
+        return Promise.resolve();
+    }
+
+    async orgOwnerChanged() {
+        return Promise.resolve();
+    }
+
+    async getProvisioning(opts: { email: string; accountId?: AccountID }) {
+        let provisioning = await super.getProvisioning(opts);
+
+        const auth = await this.storage.get(Auth, await getIdFromEmail(opts.email)).catch(() => null);
+
+        if (auth?.metaData?.oauth) {
+            if (!provisioning.account.metaData) {
+                provisioning.account.metaData = {};
+            }
+            provisioning.account.metaData.oauth = auth.metaData.oauth;
+            auth.metaData.oauth = undefined;
+            await this.storage.save(auth);
+        }
+
+        if (
+            !provisioning.account.metaData?.oauth?.lastSync ||
+            provisioning.account.metaData.oauth.lastSync < Date.now() - this.config.resyncAfter * 1000
+        ) {
+            await this._sync(provisioning);
+        }
+
+        provisioning = await super.getProvisioning(opts);
+
+        provisioning.account.skipTos = true;
+
+        return provisioning;
+    }
+
+    async accountDeleted(_params: { email: string; accountId?: string }): Promise<void> {}
+
+    private async _sync({ account }: Provisioning) {
+        if (!this.oauthConfig) {
+            throw "No oauth configuration found!";
+        }
+
+        if (!account.metaData?.oauth?.tokens) {
+            account.status = ProvisioningStatus.Unprovisioned;
+            account.statusLabel = "Access Denied";
+            account.statusMessage =
+                "You don't have permission to use this service. Please contact the service administrator.";
+            account.actionLabel = undefined;
+            account.actionUrl = undefined;
+            await this.storage.save(account);
+            return;
+        }
+
+        const body = new URLSearchParams({
+            client_id: this.oauthConfig.clientId,
+            client_secret: this.oauthConfig.clientSecret,
+            grant_type: "refresh_token",
+            refresh_token: account.metaData.oauth.tokens.refresh_token,
+        }).toString();
+
+        try {
+            const tokenRes = await request(this.oauthConfig.tokenEndpoint, "POST", body, {
+                "Content-Type": "application/x-www-form-urlencoded",
+                Accept: "application/json",
+                "Content-Length": body.length.toString(),
+            });
+
+            const tokens = JSON.parse(tokenRes);
+
+            const userInfoRaw = await request(this.oauthConfig.userInfoEndpoint, "GET", undefined, {
+                Accept: "application/json",
+                Authorization: `Bearer ${tokens.access_token}`,
+            });
+
+            account.metaData.oauth = {
+                tokens,
+                userInfo: JSON.parse(userInfoRaw),
+                lastSync: Date.now(),
+            };
+
+            const userInfo = account.metaData.oauth.userInfo;
+
+            Object.assign(account, this._getAccountProvisioningFromUserInfo(userInfo));
+
+            await this.storage.save(account);
+            return;
+        } catch (e) {
+            console.error(`Failed to fetch oauth info for ${account.email}. Error: `, e);
+            account.metaData.oauth = undefined;
+
+            account.status = ProvisioningStatus.Unprovisioned;
+            account.statusLabel = "Session Expired";
+            account.statusMessage = "Your current session has expired. Please log in again!";
+            account.actionLabel = undefined;
+            account.actionUrl = undefined;
+            await this.storage.save(account);
+            return;
+        }
+    }
+
+    protected _getAccountProvisioningFromUserInfo(userInfo: OauthUserInfo): Partial<AccountProvisioning> {
+        return {
+            status: ProvisioningStatus.Active,
+            statusLabel: "Aktive",
+            statusMessage: "",
+            actionUrl: undefined,
+            actionLabel: undefined,
+            name:
+                userInfo.name ||
+                `${userInfo.given_name || ""}${userInfo.given_name && userInfo.family_name ? " " : ""}${
+                    userInfo.family_name || ""
+                }`,
+        };
+    }
+}

--- a/packages/server/src/transport/http.ts
+++ b/packages/server/src/transport/http.ts
@@ -145,7 +145,9 @@ export function request(
             }
         );
 
-        req.write(body);
+        if (body) {
+            req.write(body);
+        }
         req.end();
     });
 }


### PR DESCRIPTION
This adds support for using oauth as a default mechanism in place of email. Currently only works with PWA and electron app.