### PR TITLE
Fix admin path deployment

### DIFF
--- a/packages/admin/webpack.config.js
+++ b/packages/admin/webpack.config.js
@@ -231,6 +231,11 @@ module.exports = {
                     // Nothing more to connect to, in non-dev
                     htmlFileContents = htmlFileContents.replace("[REPLACE_CONNECT]", "");
 
+                    // Fix favicon path for subpath installs
+                    if (adminUrlPath !== '/') {
+                        htmlFileContents = htmlFileContents.replaceAll(`"/favicon.png"`, `"${adminUrlPath}favicon.png"`);
+                    }
+
                     writeFileSync(htmlFilePath, htmlFileContents, "utf-8");
 
                     return true;

--- a/packages/admin/webpack.config.js
+++ b/packages/admin/webpack.config.js
@@ -232,8 +232,11 @@ module.exports = {
                     htmlFileContents = htmlFileContents.replace("[REPLACE_CONNECT]", "");
 
                     // Fix favicon path for subpath installs
-                    if (adminUrlPath !== '/') {
-                        htmlFileContents = htmlFileContents.replaceAll(`"/favicon.png"`, `"${adminUrlPath}favicon.png"`);
+                    if (adminUrlPath !== "/") {
+                        htmlFileContents = htmlFileContents.replaceAll(
+                            `"/favicon.png"`,
+                            `"${adminUrlPath}favicon.png"`
+                        );
                     }
 
                     writeFileSync(htmlFilePath, htmlFileContents, "utf-8");


### PR DESCRIPTION
This is a partial fix to deploying admin in a `/path`. Routing, however, doesn't work (redirects to `/` automatically on login), and probably needs some fundamental change.