### PR TITLE
Fix long tag display

### DIFF
--- a/packages/app/src/elements/items-list.ts
+++ b/packages/app/src/elements/items-list.ts
@@ -284,6 +284,10 @@ export class VaultItemListItem extends LitElement {
                 right: 0;
             }
 
+            .tag.ellipsis {
+                max-width: 10em;
+            }
+
             :host(:not(:hover)) .move-left-button,
             :host(:not(:hover)) .move-right-button {
                 visibility: hidden;

--- a/packages/app/src/styles/misc.ts
+++ b/packages/app/src/styles/misc.ts
@@ -64,6 +64,10 @@ export const misc = css`
         color: var(--color-negative);
     }
 
+    .tag.ellipsis {
+        max-width: 100px;
+    }
+
     .input-wrapper {
         display: flex;
         align-items: center;

--- a/packages/app/src/styles/misc.ts
+++ b/packages/app/src/styles/misc.ts
@@ -64,10 +64,6 @@ export const misc = css`
         color: var(--color-negative);
     }
 
-    .tag.ellipsis {
-        max-width: 100px;
-    }
-
     .input-wrapper {
         display: flex;
         align-items: center;


### PR DESCRIPTION
Fixes #616

I didn't implement the limit on input because the only time people complained about long names was with automatic imports, which wouldn't be fixed by that new limitation.

I also tried adding a tooltip, but failed, and in the end, clicking on the item allows viewing the tag without it being truncated, so it should be fine.

![Screenshot from 2022-11-25 15-07-11](https://user-images.githubusercontent.com/1239616/204013282-5a19692f-e2b5-414d-ad84-6ba9537dafe7.png)