### PR TITLE
Fix CSV import first column issue

### DIFF
--- a/packages/app/src/lib/import.ts
+++ b/packages/app/src/lib/import.ts
@@ -252,7 +252,7 @@ export async function asCSV(
               });
 
     // Ensure there's at least one nameColumn
-    if (!hasNameColumn) {
+    if (mappedItemColumns.length === 0 && !hasNameColumn) {
         itemColumns[0].type = "name";
     }
 


### PR DESCRIPTION
After spending quite some time on the UI piece, thinking something was wrong with my `lit-html` logic, I saw it was this simple fix on the import logic.

Fixes #612

Here's the CSV sample file I used to test: [csv-passwords-sample.csv](https://github.com/padloc/padloc/files/10320013/csv-passwords-sample.csv)

