### PR TITLE
Tauri macOS m1 builds

### DIFF
--- a/.github/workflows/build-tauri.yml
+++ b/.github/workflows/build-tauri.yml
@@ -28,17 +28,17 @@ jobs:
             matrix:
                 config:
                     - os: ubuntu-latest
-                    arch: x86_64
-                    rust_target: x86_64-unknown-linux-gnu
+                      arch: x86_64
+                      rust_target: x86_64-unknown-linux-gnu
                     - os: macos-latest
-                    arch: x86_64
-                    rust_target: x86_64-apple-darwin
+                      arch: x86_64
+                      rust_target: x86_64-apple-darwin
                     - os: macos-latest
-                    arch: aarch64
-                    rust_target: aarch64-apple-darwin
+                      arch: aarch64
+                      rust_target: aarch64-apple-darwin
                     - os: windows-latest
-                    arch: x86_64
-                    rust_target: x86_64-pc-windows-msvc
+                      arch: x86_64
+                      rust_target: x86_64-pc-windows-msvc
 
         runs-on: ${{ matrix.config.os }}
         steps:

--- a/.github/workflows/build-tauri.yml
+++ b/.github/workflows/build-tauri.yml
@@ -50,7 +50,7 @@ jobs:
               uses: dtolnay/rust-toolchain@stable
               with:
                 targets: ${{ matrix.config.rust_target }}
-            - uses: Swatinem/rust-cache@v1
+            - uses: Swatinem/rust-cache@v2
               with:
                 key: ${{ matrix.config.rust_target }}
             - name: Install webkit2gtk (ubuntu only)

--- a/.github/workflows/build-tauri.yml
+++ b/.github/workflows/build-tauri.yml
@@ -46,13 +46,13 @@ jobs:
             - uses: actions/setup-node@v2
               with:
                   node-version-file: ".nvmrc"
-            - name: 'Setup Rust'
+            - name: "Setup Rust"
               uses: dtolnay/rust-toolchain@stable
               with:
-                targets: ${{ matrix.config.rust_target }}
+                  targets: ${{ matrix.config.rust_target }}
             - uses: Swatinem/rust-cache@v2
               with:
-                key: ${{ matrix.config.rust_target }}
+                  key: ${{ matrix.config.rust_target }}
             - name: Install webkit2gtk (ubuntu only)
               if: matrix.config.os == 'ubuntu-latest'
               run: |

--- a/.github/workflows/build-tauri.yml
+++ b/.github/workflows/build-tauri.yml
@@ -26,20 +26,35 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                platform: [macos-latest, ubuntu-latest, windows-latest]
+                config:
+                    - os: ubuntu-latest
+                    arch: x86_64
+                    rust_target: x86_64-unknown-linux-gnu
+                    - os: macos-latest
+                    arch: x86_64
+                    rust_target: x86_64-apple-darwin
+                    - os: macos-latest
+                    arch: aarch64
+                    rust_target: aarch64-apple-darwin
+                    - os: windows-latest
+                    arch: x86_64
+                    rust_target: x86_64-pc-windows-msvc
 
-        runs-on: ${{ matrix.platform }}
+        runs-on: ${{ matrix.config.os }}
         steps:
             - uses: actions/checkout@v3
             - uses: actions/setup-node@v2
               with:
                   node-version-file: ".nvmrc"
-            - name: Install Rust stable
-              uses: actions-rs/toolchain@v1
+            - name: 'Setup Rust'
+              uses: dtolnay/rust-toolchain@stable
               with:
-                  toolchain: stable
+                targets: ${{ matrix.config.rust_target }}
+            - uses: Swatinem/rust-cache@v1
+              with:
+                key: ${{ matrix.config.rust_target }}
             - name: Install webkit2gtk (ubuntu only)
-              if: matrix.platform == 'ubuntu-latest'
+              if: matrix.config.os == 'ubuntu-latest'
               run: |
                   sudo apt-get update
                   sudo apt-get install -y webkit2gtk-4.0
@@ -63,35 +78,35 @@ jobs:
                   TAURI_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
             - name: Archive AppImage
               uses: actions/upload-artifact@v2
-              if: matrix.platform == 'ubuntu-latest'
+              if: matrix.config.os == 'ubuntu-latest'
               with:
                   name: padloc-linux-${{ github.sha }}-unsigned.AppImage
                   path: packages/tauri/src-tauri/target/debug/bundle/appimage/padloc*.AppImage
                   if-no-files-found: error
             - name: Archive deb
               uses: actions/upload-artifact@v2
-              if: matrix.platform == 'ubuntu-latest'
+              if: matrix.config.os == 'ubuntu-latest'
               with:
                   name: padloc-linux-${{ github.sha }}-unsigned.deb
                   path: packages/tauri/src-tauri/target/debug/bundle/deb/*.deb
                   if-no-files-found: error
             - name: Archive dmg
               uses: actions/upload-artifact@v2
-              if: matrix.platform == 'macos-latest'
+              if: matrix.config.os == 'macos-latest'
               with:
-                  name: padloc-macos-${{ github.sha }}-unsigned.dmg
+                  name: padloc-macos-${{ matrix.config.arch }}-${{ github.sha }}-unsigned.dmg
                   path: packages/tauri/src-tauri/target/debug/bundle/dmg/*.dmg
                   if-no-files-found: error
             - name: Archive app
               uses: actions/upload-artifact@v2
-              if: matrix.platform == 'macos-latest'
+              if: matrix.config.os == 'macos-latest'
               with:
-                  name: padloc-macos-${{ github.sha }}-unsigned.app
+                  name: padloc-macos-${{ matrix.config.arch }}-${{ github.sha }}-unsigned.app
                   path: packages/tauri/src-tauri/target/debug/bundle/macos/*.app
                   if-no-files-found: error
             - name: Archive msi
               uses: actions/upload-artifact@v2
-              if: matrix.platform == 'windows-latest'
+              if: matrix.config.os == 'windows-latest'
               with:
                   name: padloc-windows-${{ github.sha }}-unsigned.msi
                   path: packages/tauri/src-tauri/target/debug/bundle/msi/*.msi


### PR DESCRIPTION
This PR modifies the GH workflow to also build artifacts for the `aarch64-apple-darwin` target.

I also changed 2 others things:
1. Changed `actions-rs/toolchain` to `dtolnay/rust-toolchain` since the former [is unmaintained since 2020](https://github.com/actions-rs/toolchain/commits/master)
2. Added `Swatinem/rust-cache@v2` to cache rust compilation results between runs. 

closes: #495

Since changes to GH workflows are always especially sensitive changes, here's a personal project of mine that uses this setup to build for aarch64 too: [Pisano](https://github.com/JonasKruckenberg/pisano/blob/main/.github/workflows/release-nightly.yml) and a more public project (my previous employer) that uses this setup too [Mintter](https://github.com/mintterteam/mintter/blob/master/.github/workflows/release-nightly.yml)