### PR TITLE
Update package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6108,7 +6108,7 @@
         },
         "node_modules/maildev": {
             "version": "1.1.0",
-            "resolved": "git+ssh://git@github.com/padloc/maildev.git#a3ac6bf682dfb7cbb08b8b86e7b8afc9e5e41c66",
+            "resolved": "git+https://github.com/padloc/maildev.git#a3ac6bf682dfb7cbb08b8b86e7b8afc9e5e41c66",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -15191,7 +15191,7 @@
             "dev": true
         },
         "maildev": {
-            "version": "git+ssh://git@github.com/padloc/maildev.git#a3ac6bf682dfb7cbb08b8b86e7b8afc9e5e41c66",
+            "version": "git+https://github.com/padloc/maildev.git#a3ac6bf682dfb7cbb08b8b86e7b8afc9e5e41c66",
             "dev": true,
             "from": "maildev@git+https://github.com/padloc/maildev.git#master",
             "requires": {


### PR DESCRIPTION
had to change from ssh to https to successfully build the electron package had this error:

```
npm WARN prepare removing existing node_modules/ before installation
npm ERR! Error while executing:
npm ERR! /usr/bin/git ls-remote -h -t ssh://git@github.com/padloc/maildev.git
npm ERR!
npm ERR! git@github.com: Permission denied (publickey).
npm ERR! fatal: Could not read from remote repository.
npm ERR!
npm ERR! Please make sure you have the correct access rights
npm ERR! and the repository exists.
npm ERR!
npm ERR! exited with error code: 128
```