### PR TITLE
Alter LastPass Parsing for New and Legacy Formats

### DIFF
--- a/packages/app/src/lib/import.ts
+++ b/packages/app/src/lib/import.ts
@@ -424,7 +424,8 @@ export async function isLastPass(file: File): Promise<boolean> {
         const headerRow = data.split("\n")[0].trim();
         return (
             headerRow === "url,username,password,extra,name,grouping,fav" ||
-            headerRow === "url,username,password,extra,name,grouping,fav,totp"
+            headerRow === "url,username,password,extra,name,grouping,fav,totp" ||
+            headerRow === "url,username,password,totp,extra,name,grouping,fav"
         );
     } catch (error) {
         return false;


### PR DESCRIPTION
Closes #733

Allows for different CSV row parsing from a LastPass CSV file depending on the heading row format.

- add new boolean parameter `legacyFormat` to `lpParseRow` function
- alter `asLastPass` function to detect modern vs legacy format
- alter `asLastPass` function to provide `lpParseRow` with new `legacyFormat` parameter

Video shows importing process with correct item name imported in Padloc, along with the tag working correctly.

https://github.com/padloc/padloc/assets/43756494/07ac8a47-e392-4219-9681-f3ff000a4f7c

