### PR TITLE
Button item-view wait until save

### DIFF
--- a/packages/core/src/app.ts
+++ b/packages/core/src/app.ts
@@ -1605,7 +1605,7 @@ export class App {
         if (save) {
             await this.saveVault(vault);
             if (sync) {
-                await this.syncVault(vault);
+                this.syncVault(vault);
             }
         }
     }


### PR DESCRIPTION
When there are many passwords (1000+), the application becomes slow and quitting causes a rollback. The button now wait until save and start a sync in background (even if it cannot terminate, the localstorage will be pushed on the next app startup)