### PR TITLE
Synchronize only if the server is reachable

### DIFF
--- a/packages/core/src/app.ts
+++ b/packages/core/src/app.ts
@@ -577,6 +577,22 @@ export class App {
      */
     async synchronize() {
         this.setState({ syncing: true });
+        // Try to ping the server and sync only if online
+        let isServerPingable = true;
+        try {
+            let controller = new AbortController();
+            const timeoutId = setTimeout(() => controller.abort(), 5000);
+            await fetch(process.env.PL_SERVER_URL!, { signal: controller.signal });
+            clearTimeout(timeoutId);
+        } catch (error) {
+            isServerPingable = false;
+        }
+
+        if (!isServerPingable) {
+            this.setState({ syncing: false });
+            return;
+        }
+
         await this.fetchAuthInfo();
         await this.fetchAccount();
         await this.fetchOrgs();


### PR DESCRIPTION
The synchronization when the server is not reachable causes the sync to be infinite. The sync is now skipped if the server is not reachable.