### PR TITLE
Add deployment badge for Hostinger

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 Simple, secure password and data management for individuals and teams.
 
+[![Deploy on Hostinger](https://assets.hostinger.com/vps/deploy.svg)](https://www.hostinger.com/vps/docker-hosting?compose_url=https://github.com/padloc/padloc/)
+
 [![Deploy to DigitalOcean](https://www.deploytodo.com/do-btn-blue.svg)](https://cloud.digitalocean.com/apps/new?repo=https://github.com/padloc/padloc/tree/main)
 
 ## About


### PR DESCRIPTION
Added a deployment badge for Hostinger. If needed, you can change the URL link to contain the referral code to earn the commission.